### PR TITLE
Update issue templates to allow markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -16,7 +16,6 @@ body:
     attributes:
       label: Bug description
       description: Describe the bug you encountered and what you expected to happen.
-      render: shell
     validations:
       required: true
       
@@ -30,7 +29,6 @@ body:
         - Include relevant code snippet that did not work as expected.
         - If applicable, add screenshots to help explain the problem.
         - Include anything else that might help us debug the issue.
-      render: shell
     validations:
       required: true
       

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -25,7 +25,6 @@ body:
     attributes:
       label: What is your request?
       description: Describe how you'd like us to improve Mojo.
-      render: shell
     validations:
       required: true
       
@@ -34,7 +33,6 @@ body:
     attributes:
       label: What is your motivation for this change?
       description: Describe the problem that your feature seeks to address (what is the value to the product/user?).
-      render: shell
     validations:
       required: true
       
@@ -43,6 +41,5 @@ body:
     attributes:
       label: Any other details?
       description: Perhaps some minimum functional attributes the implementation should include, or other context about your feature.
-      render: shell
     validations:
       required: false


### PR DESCRIPTION
Currently when raising an issue or feature request, many of the inputs have the `shell` render type, which wraps the input in a code block with the `shell` language, you then have to go in and edit it after submitting. 

Removing these `render: shell` options makes it so you get the full markdown editor for the input, and can include your own code blocks as well as links and styling etc.