### PR TITLE
example/benchmarks: compare against numpy dot

### DIFF
--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -84,7 +84,7 @@ def run_matmul_numpy() -> Float64:
     let pymatmul: PythonObject = Python.import_module("pymatmul")
     let py = Python.import_module("builtins")
 
-    let gflops = pymatmul.benchmark_matmul_python_numpy(M, N, K).to_float64()
+    let gflops = pymatmul.benchmark_matmul_numpy(M, N, K).to_float64()
     py.print(py.str("{:<13}{:>8.3f} GFLOPS").format("Numpy:", gflops))
 
     return gflops
@@ -318,7 +318,6 @@ fn main() raises:
     # Uncomment below to test correctness of Matmuls
     # test_all()
     print("CPU Results\n")
-
     let python_gflops = run_matmul_python()
     let numpy_gflops = run_matmul_numpy()
 

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -76,7 +76,11 @@ def run_matmul_python(M: Int, N: Int, K: Int) -> Float64:
     let pymatmul: PythonObject = Python.import_module("pymatmul")
     let gflops = pymatmul.benchmark_matmul_python(M, N, K).to_float64()
     let py = Python.import_module("builtins")
-    py.print(py.str("{:<15} {:>8.3f} GFLOPS").format("Python", gflops))
+    py.print(py.str("{:<15}\t{:>8.3f} GFLOPS").format("Python:", gflops))
+
+    let numpy_gflops = pymatmul.benchmark_matmul_python_numpy(M, N, K).to_float64()
+    py.print(py.str("{:<15}\t{:>8.3f} GFLOPS").format("Python (Numpy):", numpy_gflops))
+
     return gflops
 
 
@@ -263,7 +267,7 @@ fn benchmark[
 
     let py = Python.import_module("builtins")
     _ = py.print(
-        py.str("{:<15} {:>8.3f} GFLOPS {:>15.2f}x faster than Python").format(
+        py.str("{:<15}\t{:>8.3f} GFLOPS {:>15.2f}x faster than Python").format(
             str, gflops, speedup
         )
     )

--- a/examples/pymatmul.py
+++ b/examples/pymatmul.py
@@ -44,9 +44,6 @@ def matmul_python(C, A, B):
             for n in range(C.cols):
                 C[m, n] += A[m, k] * B[k, n]
 
-def matmul_python_numpy(A, B):
-    return np.dot(A, B)
-
 def benchmark_matmul_python(M, N, K):
     A = PyMatrix(list(np.random.rand(M, K)), M, K)
     B = PyMatrix(list(np.random.rand(K, N)), K, N)
@@ -55,10 +52,10 @@ def benchmark_matmul_python(M, N, K):
     gflops = ((2 * M * N * K) / secs) / 1e9
     return gflops
 
-def benchmark_matmul_python_numpy(M, N, K):
+def benchmark_matmul_numpy(M, N, K):
     A = np.random.rand(M, K)
     B = np.random.rand(K, N)
-    secs = timeit(lambda: matmul_python_numpy(A, B), number=2) / 2
+    secs = timeit(lambda: np.dot(A, B), number=2) / 2
     gflops = ((2 * M * N * K) / secs) / 1e9
     return gflops
 

--- a/examples/pymatmul.py
+++ b/examples/pymatmul.py
@@ -44,12 +44,21 @@ def matmul_python(C, A, B):
             for n in range(C.cols):
                 C[m, n] += A[m, k] * B[k, n]
 
+def matmul_python_numpy(A, B):
+    return np.dot(A, B)
 
 def benchmark_matmul_python(M, N, K):
     A = PyMatrix(list(np.random.rand(M, K)), M, K)
     B = PyMatrix(list(np.random.rand(K, N)), K, N)
     C = PyMatrix(list(np.zeros((M, N))), M, N)
     secs = timeit(lambda: matmul_python(C, A, B), number=2) / 2
+    gflops = ((2 * M * N * K) / secs) / 1e9
+    return gflops
+
+def benchmark_matmul_python_numpy(M, N, K):
+    A = np.random.rand(M, K)
+    B = np.random.rand(K, N)
+    secs = timeit(lambda: matmul_python_numpy(A, B), number=2) / 2
     gflops = ((2 * M * N * K) / secs) / 1e9
     return gflops
 


### PR DESCRIPTION
Generally no one is doing such a naive matmul I don't think, I'm thinking something like this is a bit more realistic. 

IMO, something like this is great to show that mojo has quite a bit to offer over numpy's matrix ops as well (a question that I had until I ran this)

```
$ mojo matmul.mojo
Python:        	   0.006 GFLOPS
Python (Numpy):	   1.603 GFLOPS
Naive:         	   5.920 GFLOPS         1052.24x faster than Python
Vectorized:    	  20.414 GFLOPS         3628.55x faster than Python
Parallelized:  	  43.906 GFLOPS         7804.28x faster than Python
Tiled:         	  47.673 GFLOPS         8473.98x faster than Python
Unrolled:      	  55.627 GFLOPS         9887.68x faster than Python
Accumulated:   	 436.572 GFLOPS        77601.01x faster than Python
```