### PR TITLE
fix: Dockerfile Modular Auth

### DIFF
--- a/examples/docker/Dockerfile.mojosdk
+++ b/examples/docker/Dockerfile.mojosdk
@@ -54,8 +54,9 @@ RUN pip install \
 ARG AUTH_KEY=5ca1ab1e
 ENV AUTH_KEY=$AUTH_KEY
 
-RUN curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh - \
-    && modular install mojo
+RUN curl https://get.modular.com | sh -
+RUN modular auth $AUTH_KEY && \
+    modular install mojo 
 
 ARG MODULAR_HOME="/root/.modular"
 ENV MODULAR_HOME=$MODULAR_HOME


### PR DESCRIPTION
First of all: Amazing jog! Congrats!
---

I had an error when I tried to run the Docker version:
The authentication fails. I believe Modular changes the way authentication works.

**My Setup:**
- Intel  i5-13600K
- 32 GB RAM
- WSL2 Ubuntu 22.04 LTS
- Windows 11 Pro Insider Preview x64 (v. 22H2  Build Windows 11 Pro Insider Preview)
- Docker Desktop 4.22.0 (117440)

**Replicating Steps:**
Inside docker directory:
```
docker compose up
```
Terminal Print:
```
127.3 sh: 80: [[: not found
127.3   __  __           _       _
127.3  |  \/  | ___   __| |_   _| | __ _ _ __
127.3  | |\/| |/ _ \ / _` | | | | |/ _` | '__|
127.3  | |  | | (_) | (_| | |_| | | (_| | |
127.3  |_|  |_|\___/ \__,_|\__,_|_|\__,_|_|
127.3 
127.3 Welcome to the Modular CLI!
127.3 For info about this tool, type "modular --help".
127.3 
127.3 To install Mojo🔥, type "modular install mojo".
127.3 
127.3 For Mojo documentation, see https://docs.modular.com/mojo.
127.3 To chat on Discord, visit https://discord.gg/modular.
127.3 To report issues, go to https://github.com/modularml/mojo/issues.
133.0 modular: error: please run `modular auth` before attempting to install a package
------
failed to solve: process "/bin/sh -c curl https://get.modular.com | MODULAR_AUTH=$AUTH_KEY sh -     && modular install mojo" did not complete successfully: exit code: 1
```