### PR TITLE
Update readme to de-emphasize the Mojo Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@ We plan to open-source Mojo progressively over time, but it's changing very quic
 We believe that a small, tight-knit group of engineers with a shared vision can move 
 faster than a community effort, so we will continue to incubate it within Modular until 
 it's more complete.  Please see the [Mojo FAQ](https://docs.modular.com/mojo/faq.html)
-for more information about this and other common questions. 
+for more information about this and other common questions. We've opened this repo now
+because we want to gather issues and engage in feedback from Mojo users. 
 
-We've opened this repo now because we want to gather issues and engage in feedback 
-from users who have access to the Mojo Playground (our hosted JupyterHub,
-where you can try coding with an early version of Mojo). 
-To get access to the Mojo Playground, [see here to sign up](https://docs.modular.com/mojo/get-started.html).
+[See here to get started with Mojo](https://docs.modular.com/mojo/manual/get-started/).
 Then, when you want to report issues or request features,
 [please create a GitHub issue here](https://github.com/modularml/mojo/issues).
 


### PR DESCRIPTION
The Mojo SDK is also available for local development, but there's no need to explain the differences here. Instead, we can just link to the get started guide that explains the latest Mojo SDK and Mojo Playground.

Fixes https://github.com/modularml/mojo/issues/1220