### PR TITLE
[examples] Improve `example/matmul` perf by 2.3x 

### DIFF
--- a/examples/pymatmul.py
+++ b/examples/pymatmul.py
@@ -58,4 +58,6 @@ def benchmark_matmul_numpy(M, N, K):
 
 if __name__ == "__main__":
     print("Throughput of a 128x128 matrix multiplication in Python:")
-    benchmark_matmul_python(128, 128, 128)
+    print(benchmark_matmul_python(128, 128, 128))
+    print("Throughput of a 128x128 matrix multiplication in Python numpy:")
+    print(benchmark_matmul_numpy(128, 128, 128))


### PR DESCRIPTION
```
CPU Results

Python:         0.005 GFLOPS
Numpy:        125.389 GFLOPS
Naive:          7.611 GFLOPS   1684.48x Python  0.06x Numpy
Vectorized:    31.086 GFLOPS   6880.12x Python  0.25x Numpy
Parallelized:  82.079 GFLOPS  18166.06x Python  0.65x Numpy
Tiled:         94.447 GFLOPS  20903.58x Python  0.75x Numpy
Unrolled:      89.493 GFLOPS  19807.11x Python  0.71x Numpy
Accumulated:  323.471 GFLOPS  71592.24x Python  2.58x Numpy
Loop reordered: 624.812 GFLOPS 138286.61x Python  4.98x Numpy
Loop reordered (swizzled): 697.969 GFLOPS 154478.04x Python  5.57x Numpy
```