### PR TITLE
Fix a few typos in docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -916,7 +916,7 @@ modular install mojo
 - [#753](https://github.com/modularml/mojo/issues/753) - Direct use of LLVM
   dialect produces strange errors in the compiler.
 - [#926](https://github.com/modularml/mojo/issues/926) - Fixes an issue that
-  occured when a function with a return type of `StringRef` raised an error.
+  occurred when a function with a return type of `StringRef` raised an error.
   When the function raised an error, it incorrectly returned the string value of
   that error.
 - [#536](https://github.com/modularml/mojo/issues/536) - Report More information

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -317,7 +317,7 @@ silicon). Support for Windows will follow. Until then, you have several options:
 
 - Windows users can use
   [Windows Subsystem for Linux version 2 (WSL 2)](https://learn.microsoft.com/en-us/windows/wsl/install)
-  running a supported Linix distribution.
+  running a supported Linux distribution.
 - Intel Mac users can use a [Docker](https://www.docker.com/) container running
   a supported Linux distribution.
 - Users on any system can install the SDK on a remote machine running a

--- a/docs/manual/python/types.ipynb
+++ b/docs/manual/python/types.ipynb
@@ -197,7 +197,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "In the previous exmaple, the `pySet.__len__()` method returns a `PythonObject` \n",
+                "In the previous example, the `pySet.__len__()` method returns a `PythonObject` \n",
                 "holding an integer. The `int()` built-in function returns a Mojo integer. In \n",
                 "Python you'd usually write this as `len(pySet)`. This is a TODO item: the Mojo \n",
                 "code requires this temporary workaround because Mojo's `len()` built-in doesn't\n",

--- a/docs/manual/values/ownership.ipynb
+++ b/docs/manual/values/ownership.ipynb
@@ -446,7 +446,7 @@
     "### Transfer implementation details\n",
     "\n",
     "In Mojo, it's important that you not conflate \"ownership transfer\" with a \"move\n",
-    "operation\"—these are not stricly the same thing. \n",
+    "operation\"—these are not strictly the same thing. \n",
     "\n",
     "There are multiple ways that Mojo can transfer ownership of a value without\n",
     "making a copy:\n",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -708,7 +708,7 @@ print(1//0) # does not raise and could print anything (undefined behaviour)
 
 This is clearly unacceptable given the strong memory safety goals of Mojo. We
 will circle back to this when more language features and language-level
-optimizations are avaiable.
+optimizations are available.
 
 ### Nested functions cannot be recursive
 

--- a/examples/blogs-videos/mojo-plotter/README.md
+++ b/examples/blogs-videos/mojo-plotter/README.md
@@ -8,7 +8,7 @@ If you don't have `conda`, install [miniconda here](https://docs.conda.io/projec
 
 ### Create conda environment
 
-Create and acivate conda enironment:
+Create and activate conda environment:
 
 #### General
 

--- a/examples/blogs-videos/whats_new_v0.5.ipynb
+++ b/examples/blogs-videos/whats_new_v0.5.ipynb
@@ -237,7 +237,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Benchmark row-wise `mean()` of a matrix by vectorizing across colums and parallelizing across rows"
+    "Benchmark row-wise `mean()` of a matrix by vectorizing across columns and parallelizing across rows"
    ]
   },
   {

--- a/examples/notebooks/RayTracing.ipynb
+++ b/examples/notebooks/RayTracing.ipynb
@@ -126,7 +126,7 @@
       "id": "2619eb1b-103b-4453-9725-4480e388452e",
       "metadata": {},
       "source": [
-        "We now define our `Image` struct, which will store the RGB pixels of our images. It also contains a method to conver this Mojo struct into a numpy image, which will be used for implementing a straightforward displaying mechanism. We will also implement a function for loading PNG files from disk."
+        "We now define our `Image` struct, which will store the RGB pixels of our images. It also contains a method to convert this Mojo struct into a numpy image, which will be used for implementing a straightforward displaying mechanism. We will also implement a function for loading PNG files from disk."
       ]
     },
     {

--- a/examples/notebooks/programming-manual.ipynb
+++ b/examples/notebooks/programming-manual.ipynb
@@ -690,7 +690,7 @@
       "source": [
         "Mojo also supports the `__moveinit__` method which allows both Rust-style\n",
         "moves (which transfers a value from one place to another when the source lifetime ends) and the `__takeinit__` method for C++-style moves (where the\n",
-        "contents of a value is logically transfered out of the source, but its destructor is still run), and allows\n",
+        "contents of a value is logically transferred out of the source, but its destructor is still run), and allows\n",
         "defining custom move logic. For more detail, see the [Value\n",
         "Lifecycle](#value-lifecycle-birth-life-and-death-of-a-value)\n",
         "section below.\n",
@@ -3246,7 +3246,7 @@
         "\n",
         "    let ts2 : TwoStrings # ts2 type is declared but not initialized\n",
         "    ts2.str1 = String(\"foo\")\n",
-        "    ts2.str2 = String(\"bar\")  # Both the member are initalized\n",
+        "    ts2.str2 = String(\"bar\")  # Both the member are initialized\n",
         "    # Uncomment to see an error:\n",
         "    # use(ts2) # Error: 'ts2' isn't fully initialized\n"
       ]

--- a/proposals/mojo-and-dynamism.md
+++ b/proposals/mojo-and-dynamism.md
@@ -130,7 +130,7 @@ The fourth category isn't explored here, but will important when/if we support s
 
 The highest level of dynamism and the most faithful compatibility doesn't come from Mojo itself, it comes from Mojo's first class interoperability with CPython.  This in effect will be Mojo's escape hatch for compatibility purposes and is what gives Mojo access to all of Python's vast ecosystem.  Below that, Mojo will provide an emulation of Python's hash-table dynamism that is a faithful but not quite identical replication of Python behaviour (no GIL, for example!).  Building this out will be a huge undertaking, and is something Mojo should do over time.
 
-The most important thing to remember is that Mojo is not a "Python compiler".  The benefit of sharing the same syntax as Python, however, means seemless interop is on the table:
+The most important thing to remember is that Mojo is not a "Python compiler".  The benefit of sharing the same syntax as Python, however, means seamless interop is on the table:
 
 ```python
 @python

--- a/workshops/mojo_for_python_developers/2_speeding_up_python.ipynb
+++ b/workshops/mojo_for_python_developers/2_speeding_up_python.ipynb
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Exercise: Copy over the pure-Python function into Mojo🔥 and variable declations and return types, you did in notebook 1. \n",
+    "Exercise: Copy over the pure-Python function into Mojo🔥 and variable declarations and return types, you did in notebook 1. \n",
     "\n",
     "<details><summary><b>Solution</b></summary>\n",
     "<pre>\n",
@@ -214,7 +214,7 @@
    "source": [
     "To vectorize our naive `mojo_dist` function, we'll write a closure that is parameterized on `simd_width`. Rather than operate on individual elements, we'll work with `simd_width` elements which gives us speed ups. You can access `simd_width` elements using `simd_load`.\n",
     "\n",
-    "Given that this is a complex topic, I've provided the solution below, please raise your hand and ask the instructor for explainations if anything is unclear.\n"
+    "Given that this is a complex topic, I've provided the solution below, please raise your hand and ask the instructor for explanations if anything is unclear.\n"
    ]
   },
   {

--- a/workshops/mojo_for_python_developers/3_parallelization_speedup_tensor_mean.ipynb
+++ b/workshops/mojo_for_python_developers/3_parallelization_speedup_tensor_mean.ipynb
@@ -12,7 +12,7 @@
    "metadata": {},
    "source": [
     "## Speeding up Python in Mojo🔥 using vectorization and parallelization\n",
-    "#### Example: Calculate row-wise `mean()` of a matrix by vectorizing across colums and parallelizing across rows"
+    "#### Example: Calculate row-wise `mean()` of a matrix by vectorizing across columns and parallelizing across rows"
    ]
   },
   {
@@ -64,7 +64,7 @@
     "# Note: This function will give you an error. \n",
     "# Run the last cell in the notebook that defines `tensorprint` and then \n",
     "# come back and run this cell. The `tensorprint` is temporary helper function \n",
-    "# untill we have native print support for tensors in the next release"
+    "# until we have native print support for tensors in the next release"
    ]
   },
   {


### PR DESCRIPTION
Found by running [`typos`](https://github.com/crate-ci/typos) with the following `_typos.toml` config:

```toml
[default.extend-words]
inout = "inout"
ND = "ND" # NDBuffer
nane = "nane" # Wrong on purpose in an example.
mis = "mis" # mis-features
```