### PR TITLE
Fix wrong link to Language basics page (on Functions page)

### DIFF
--- a/docs/manual/functions.ipynb
+++ b/docs/manual/functions.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As mentioned in [Language basics](/mojo/manual/basics/), Mojo supports two\n",
+    "As mentioned in [Language basics](/mojo/manual/basics), Mojo supports two\n",
     "types of functions: `def` and `fn` functions. You can use either declaration\n",
     "with any function, including the `main()` function, but they have different\n",
     "default behaviors, as described on this page.\n",


### PR DESCRIPTION
Under [Functions page](https://docs.modular.com/mojo/manual/functions.html), there is a link to the [Language basics page](https://docs.modular.com/mojo/manual/basics.html). Currently, clicking on the link, it shows `Page not found` due to the wrong URL (a slash is redundant at the end).

![image](https://github.com/modularml/mojo/assets/4323410/adb29a5e-0ef8-40f4-b2fd-3c933320fb50)


What has been fixed: Removed the redundant slash

Signed-off-by: Phuc Tran <phuc@bumbii.tech>