### PR TITLE
small typo fix

### DIFF
--- a/docs/manual/variables.ipynb
+++ b/docs/manual/variables.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "source": [
     "The `name` variable is mutable, so you can change it later, but if you try to\n",
-    "change `id` after it's initialized, you'll get a compiler error. (You can\n",
+    "change `user_id` after it's initialized, you'll get a compiler error. (You can\n",
     "initialize the value later if you [specify the type](#type-annotations).)\n",
     "\n",
     "Using `var` helps prevent runtime errors caused by typos. For example, if you\n",


### PR DESCRIPTION
where previously the variable name in text was different from code sample it was referring to.

Signed-off-by: Ken Shih ken.shih@gmail.com