### PR TITLE
docs and example update

### DIFF
--- a/docs/manual/lifecycle/life.ipynb
+++ b/docs/manual/lifecycle/life.ipynb
@@ -347,7 +347,7 @@
         "        # Deep-copy the existing value\n",
         "        self.size = existing.size\n",
         "        self.cap = existing.cap\n",
-        "        self.data = Pointer[Int].alloc(self.size)\n",
+        "        self.data = Pointer[Int].alloc(self.cap)\n",
         "        for i in range(self.size):\n",
         "            self.data.store(i, existing.data.load(i))\n",
         "        # The lifetime of `existing` continues unchanged\n",

--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -289,7 +289,7 @@
                 "For a real-world example of a parameterized type, let's look at the \n",
                 "[`SIMD`](/mojo/stdlib/builtin/simd.html) type from Mojo's standard library.\n",
                 "\n",
-                "[Single instruction, multiple data (SIMD)](https://en.wikipediv1.org/wiki/Single_instruction,_multiple_data) is a parallel processing technology built into many modern CPUs,\n",
+                "[Single instruction, multiple data (SIMD)](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) is a parallel processing technology built into many modern CPUs,\n",
                 "GPUs, and custom accelerators. SIMD allows you to perform a single operation on\n",
                 "multiple pieces of data at once. For example, if you want to take the square \n",
                 "root of each element in array, you can use SIMD to parallelize the work. \n",


### PR DESCRIPTION
In the HeapArray example, set the "cap" size as the total allocation for the pointer rather than the "size" of the current allocated elements. 

![image](https://github.com/modularml/mojo/assets/25770922/c519ab32-5de8-4563-b199-891f7e430085)


Signed-off-by: Rahul D Shetty [35rahuldshetty@gmail.com](mailto:35rahuldshetty@gmail.com)