### PR TITLE
Fix typo in Mojo doc.

### DIFF
--- a/docs/manual/variables.ipynb
+++ b/docs/manual/variables.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "source": [
     "The `name` variable is mutable, so you can change it later, but if you try to\n",
-    "change `id` after it's initialized, you'll get a compiler error. (You can\n",
+    "change `user_id` after it's initialized, you'll get a compiler error. (You can\n",
     "initialize the value later if you [specify the type](#type-annotations).)\n",
     "\n",
     "Using `var` helps prevent runtime errors caused by typos. For example, if you\n",


### PR DESCRIPTION
Found a typo while reading the variable section in Mojo doc