### PR TITLE
Fixed typo.

### DIFF
--- a/docs/manual/traits.ipynb
+++ b/docs/manual/traits.ipynb
@@ -405,7 +405,7 @@
                 "# Standard constructor, as declared in a trait\n",
                 "fn __init__(self, i: Int):\n",
                 "# Register-passable constructor\n",
-                "fn __init__(i Int) -> Self:\n",
+                "fn __init__(i: Int) -> Self:\n",
                 "```"
             ]
         },


### PR DESCRIPTION
An implementation based on this example compiles only after this typo fix. [jump to change](https://github.com/modularml/mojo/pull/1498/commits/18dd663b7ea6496c4b4be452aa15c96240653483)

Signed-off-by: Anirban Chatterjee <anirban.chatterjee012@gmail.com>