### PR TITLE
nbody.mojo - remove unnecessary memory writes and @unroll inner loop

### DIFF
--- a/examples/nbody.mojo
+++ b/examples/nbody.mojo
@@ -63,9 +63,7 @@ fn advance(inout bodies: StaticTuple[NUM_BODIES, Planet], dt: Float64):
     for i in range(NUM_BODIES):
         var body_i = bodies[i]
 
-        # @unroll(NUM_BODIES - 1) errors.
-        # Bug reported at https://github.com/modularml/mojo/pull/1534
-        @unroll(4)
+        @unroll(NUM_BODIES - 1)
         for j in range(NUM_BODIES - i - 1):
             var body_j = bodies[j + i + 1]
             let diff = body_i.pos - body_j.pos

--- a/examples/nbody.mojo
+++ b/examples/nbody.mojo
@@ -62,6 +62,10 @@ fn advance(inout bodies: StaticTuple[NUM_BODIES, Planet], dt: Float64):
     @unroll
     for i in range(NUM_BODIES):
         var body_i = bodies[i]
+
+        # @unroll(NUM_BODIES - 1) errors.
+        # Bug reported at https://github.com/modularml/mojo/pull/1534
+        @unroll(4)
         for j in range(NUM_BODIES - i - 1):
             var body_j = bodies[j + i + 1]
             let diff = body_i.pos - body_j.pos

--- a/examples/nbody.mojo
+++ b/examples/nbody.mojo
@@ -61,8 +61,8 @@ fn offset_momentum(inout bodies: StaticTuple[NUM_BODIES, Planet]):
 fn advance(inout bodies: StaticTuple[NUM_BODIES, Planet], dt: Float64):
     @unroll
     for i in range(NUM_BODIES):
+        var body_i = bodies[i]
         for j in range(NUM_BODIES - i - 1):
-            var body_i = bodies[i]
             var body_j = bodies[j + i + 1]
             let diff = body_i.pos - body_j.pos
             let diff_sqr = (diff * diff).reduce_add()
@@ -71,8 +71,9 @@ fn advance(inout bodies: StaticTuple[NUM_BODIES, Planet], dt: Float64):
             body_i.velocity -= diff * body_j.mass * mag
             body_j.velocity += diff * body_i.mass * mag
 
-            bodies[i] = body_i
             bodies[j + i + 1] = body_j
+
+        bodies[i] = body_i
 
     @unroll
     for i in range(NUM_BODIES):


### PR DESCRIPTION
Edit: I found a second optimisation unrolling the inner loop so the total improvement is 6.53 -> 1.13 seconds on M1 Pro.  That change is discussed in the next comment.

------------------
On M1 Pro the result of `benchmark()` falls from 6.53 to 4.40 seconds.  I realise this code is reproducing a specific benchmark but some of the other competitors do this optimisation so I think it is fine.

One of the [Julia code examples](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-julia-8.html) explains it well. 

```
    @inbounds for i=1:4
        bi = bodies[i]
        # For body i, since velocity is the only part of the object
        # changing on each iteration, it's more efficient to update
        # outside the vector.
        iv = bi.v
        for j=i+1:5
            iv = iv .- Δx[k] .* (mag[k] * bodies[j].m)
            bodies[j] = Body(bodies[j].x,
                             bodies[j].v .+ Δx[k] .* (mag[k] * bi.m),
                             bodies[j].m)
            k += 1
        end
        bodies[i] = Body(bi.x, iv, bi.m)
    end
```