### PR TITLE
Fix typo under docs/manual/values/value-semantics.ipynb

### DIFF
--- a/docs/manual/values/value-semantics.ipynb
+++ b/docs/manual/values/value-semantics.ipynb
@@ -253,7 +253,7 @@
     "\n",
     "The way we do that in Mojo is, instead of enforcing that every variable have\n",
     "\"exclusive access\" to a value, we ensure that every value has an \"exclusive\n",
-    "owner,\" and destroy each values when the lifetime of its owner ends. \n",
+    "owner,\" and destroy each value when the lifetime of its owner ends. \n",
     "\n",
     "On the next page about [value\n",
     "ownership]((/mojo/manual/values/value-semantics.html)), you'll learn how modify\n",


### PR DESCRIPTION
Just a small spelling error, in the section titled "Value semantics in `def` vs `fn`".