### PR TITLE
Fix typo in structs.ipynb

### DIFF
--- a/docs/manual/structs.ipynb
+++ b/docs/manual/structs.ipynb
@@ -459,7 +459,7 @@
    "source": [
     "When you add the `@value` decorator, Mojo synthesizes each special method above\n",
     "only if it doesn't exist already. That is, you can still implement a custom\n",
-    "version of each method methods.\n",
+    "version of each method.\n",
     "\n",
     "In addition to the `inout` argument convention you already saw with\n",
     "`__init__()`, this code also introduces `owned`, which is another argument\n",


### PR DESCRIPTION
Fixes a small typo.