### PR TITLE
Typo fix

### DIFF
--- a/docs/manual/values/value-semantics.ipynb
+++ b/docs/manual/values/value-semantics.ipynb
@@ -256,7 +256,7 @@
     "owner,\" and destroy each value when the lifetime of its owner ends. \n",
     "\n",
     "On the next page about [value\n",
-    "ownership]((/mojo/manual/values/value-semantics.html)), you'll learn how modify\n",
+    "ownership]((/mojo/manual/values/value-semantics.html)), you'll learn how to modify\n",
     "the default argument conventions, and safely use reference semantics so every\n",
     "value has only one owner at a time."
    ]


### PR DESCRIPTION
A simple typo fix that adds "to".

Before: "you'll learn how modify
the default argument conventions"

After: "you'll learn how to modify
the default argument conventions"

-----------

Thoroughly enjoying your docs, btw!