### PR TITLE
CI update to get the modular installer, install mojo compiler

### DIFF
--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -15,4 +15,8 @@ jobs:
           echo "Downloading the Latest Mojo Compiler"
           curl https://get.modular.com | sh - && modular auth buildAndTestMojoOSS
           modular install mojo
+          BASHRC=$( [ -f "$HOME/.bash_profile" ] && echo "$HOME/.bash_profile" || echo "$HOME/.bashrc" )
+          echo 'export MODULAR_HOME="/home/runner/.modular"' >> "$BASHRC"
+          echo 'export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"' >> "$BASHRC"
+          source "$BASHRC"
           mojo --version

--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -8,3 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: "Get the modular installer, install mojo compiler"
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install modular
+          modular clean
+          modular install mojo
+          mojo --version

--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -12,12 +12,7 @@ jobs:
       - name: "Get the modular installer, install mojo compiler"
         shell: bash
         run: |
-          sudo apt-get install -y apt-transport-https &&
-            keyring_location=/usr/share/keyrings/modular-installer-archive-keyring.gpg &&
-            curl -1sLf 'https://dl.modular.com/bBNWiLZX5igwHXeu/installer/gpg.0E4925737A3895AD.key' |  gpg --dearmor >> ${keyring_location} &&
-            curl -1sLf 'https://dl.modular.com/bBNWiLZX5igwHXeu/installer/config.deb.txt?distro=debian&codename=wheezy' > /etc/apt/sources.list.d/modular-installer.list &&
-            apt-get update &&
-            apt-get install -y modular
-          modular auth buildAndTestMojoOSS
+          echo "Downloading the Latest Mojo Compiler"
+          curl https://get.modular.com | sh - && modular auth buildAndTestMojoOSS
           modular install mojo
           mojo --version

--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -12,8 +12,12 @@ jobs:
       - name: "Get the modular installer, install mojo compiler"
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install modular
-          modular clean
+          sudo apt-get install -y apt-transport-https &&
+            keyring_location=/usr/share/keyrings/modular-installer-archive-keyring.gpg &&
+            curl -1sLf 'https://dl.modular.com/bBNWiLZX5igwHXeu/installer/gpg.0E4925737A3895AD.key' |  gpg --dearmor >> ${keyring_location} &&
+            curl -1sLf 'https://dl.modular.com/bBNWiLZX5igwHXeu/installer/config.deb.txt?distro=debian&codename=wheezy' > /etc/apt/sources.list.d/modular-installer.list &&
+            apt-get update &&
+            apt-get install -y modular
+          modular auth buildAndTestMojoOSS
           modular install mojo
           mojo --version


### PR DESCRIPTION
This PR includes logic to download the modular installer and use it to install the mojo compiler.