### PR TITLE
Fix typo in BoolMLIR.ipynb

### DIFF
--- a/examples/notebooks/BoolMLIR.ipynb
+++ b/examples/notebooks/BoolMLIR.ipynb
@@ -574,7 +574,7 @@
    "source": [
     "## The promise of modularity\n",
     "\n",
-    "As we've seen, Mojo's integration with MLIR allows Mojo programmers to implement zero-cost abstractons on par with Mojo's own builtin and standard library types.\n",
+    "As we've seen, Mojo's integration with MLIR allows Mojo programmers to implement zero-cost abstractions on par with Mojo's own built-in and standard library types.\n",
     "\n",
     "MLIR is open-source and extensible: new dialects are being added all the time, and those dialects then become available to use in Mojo. All the while, Mojo code gets more powerful and more optimized for new hardware -- with no additional work necessary by Mojo programmers.\n",
     "\n",


### PR DESCRIPTION
Two small typo fixes:

1. `abstractons` -> `abstractions`
2. `builtin` -> `built-in`