### PR TITLE
Fix typo in Matmul.ipynb

### DIFF
--- a/examples/notebooks/Matmul.ipynb
+++ b/examples/notebooks/Matmul.ipynb
@@ -64,7 +64,7 @@
       "source": [
         "<div class=\"alert alert-block alert-success alert--secondary\">\n",
         "\n",
-        "Please take look at our [blog](https://www.modular.com/blog/ais-compute-fragmentation-what-matrix-multiplication-teaches-us) post on matmul and why it is important for ML and DL workloads.\n",
+        "Please take a look at our [blog](https://www.modular.com/blog/ais-compute-fragmentation-what-matrix-multiplication-teaches-us) post on matmul and why it is important for ML and DL workloads.\n",
         "\n",
         "</div>"
       ]
@@ -849,7 +849,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "One source of overhead in the above implementation is the fact that the we are not unrolling the loops introduced by vectorize of the dot function. We can do that via the `vectorize_unroll` higher-order function in Mojo:"
+        "One source of overhead in the above implementation is the fact that we are not unrolling the loops introduced by vectorize of the dot function. We can do that via the `vectorize_unroll` higher-order function in Mojo:"
       ]
     },
     {


### PR DESCRIPTION
Two simple typo fixes:

- `take look at` -> `take a look at`
- delete an extra `the`
