### PR TITLE
Update BoolMLIR.ipynb for Mojo 2024.1.0

### DIFF
--- a/examples/notebooks/BoolMLIR.ipynb
+++ b/examples/notebooks/BoolMLIR.ipynb
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "let b = OurBool()"
+    "var b = OurBool()"
    ]
   },
   {
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,12 +190,10 @@
     "struct OurBool:\n",
     "    var value: __mlir_type.i1\n",
     "\n",
-    "    fn __init__() -> Self:\n",
-    "        return Self {\n",
-    "            value: __mlir_op.`index.bool.constant`[\n",
-    "                value=__mlir_attr.`false`,\n",
-    "            ]()\n",
-    "        }"
+    "    fn __init__(inout self):\n",
+    "        self.value = __mlir_op.`index.bool.constant`[\n",
+    "            value=__mlir_attr.`false`,\n",
+    "        ]()"
    ]
   },
   {
@@ -207,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "tags": []
    },
@@ -240,8 +238,8 @@
     "\n",
     "    # ...\n",
     "\n",
-    "    fn __init__(value: __mlir_type.i1) -> Self:\n",
-    "        return Self {value: value}"
+    "    fn __init__(inout self, value: __mlir_type.i1):\n",
+    "        self.value = value"
    ]
   },
   {
@@ -253,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "tags": []
    },
@@ -284,12 +282,12 @@
    "source": [
     "`OurFalse` is declared to be of type `OurBool`, and then assigned an `i1` type -- in this case, the `OurBool` constructor we added is called implicitly.\n",
     "\n",
-    "With true and false constants, we can also simplify our original `__init__` constructor for `OurBool`. Instead of constructing an MLIR value, we can simply return our `OurFalse` constant:"
+    "We can also make use of Mojo's default arguments to create automatically a `False` value when the constructor of `OurBool` is called without arguments. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
     "tags": []
    },
@@ -303,12 +301,8 @@
     "struct OurBool:\n",
     "    var value: __mlir_type.i1\n",
     "\n",
-    "    # We can simplify our no-argument constructor:\n",
-    "    fn __init__() -> Self:\n",
-    "        return OurFalse\n",
-    "\n",
-    "    fn __init__(value: __mlir_type.i1) -> Self:\n",
-    "        return Self {value: value}"
+    "    fn __init__(inout self, value: __mlir_type.i1 = __mlir_attr.`false`):\n",
+    "        self.value = value"
    ]
   },
   {
@@ -322,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {
     "tags": []
    },
@@ -354,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {
     "tags": []
    },
@@ -368,10 +362,8 @@
     "struct OurBool:\n",
     "    var value: __mlir_type.i1\n",
     "\n",
-    "    # ...\n",
-    "\n",
-    "    fn __init__(value: __mlir_type.i1) -> Self:\n",
-    "        return Self {value: value}\n",
+    "    fn __init__(inout self, value: __mlir_type.i1 = __mlir_attr.`false`):\n",
+    "        self.value = value\n",
     "\n",
     "    # Our new method converts `OurBool` to `Bool`:\n",
     "    fn __bool__(self) -> Bool:\n",
@@ -387,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -430,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,8 +434,8 @@
     "struct OurBool:\n",
     "    var value: __mlir_type.i1\n",
     "\n",
-    "    fn __init__(value: __mlir_type.i1) -> Self:\n",
-    "        return Self {value: value}\n",
+    "    fn __init__(inout self, value: __mlir_type.i1 = __mlir_attr.`false`):\n",
+    "        self.value = value\n",
     "\n",
     "    # Our new method converts `OurBool` to `i1`:\n",
     "    fn __mlir_i1__(self) -> __mlir_type.i1:\n",
@@ -459,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -496,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,8 +500,8 @@
     "struct OurBool:\n",
     "    var value: __mlir_type.i1\n",
     "\n",
-    "    fn __init__(value: __mlir_type.i1) -> Self:\n",
-    "        return Self {value: value}\n",
+    "    fn __init__(inout self, value: __mlir_type.i1 = __mlir_attr.`false`):\n",
+    "        self.value = value\n",
     "\n",
     "    # ...\n",
     "\n",
@@ -542,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {

--- a/examples/notebooks/BoolMLIR.ipynb
+++ b/examples/notebooks/BoolMLIR.ipynb
@@ -282,7 +282,7 @@
    "source": [
     "`OurFalse` is declared to be of type `OurBool`, and then assigned an `i1` type -- in this case, the `OurBool` constructor we added is called implicitly.\n",
     "\n",
-    "We can also make use of Mojo's default arguments to create automatically a `False` value when the constructor of `OurBool` is called without arguments. "
+    "We can also make use of Mojo's default arguments to automatically create a `False` value when the constructor of `OurBool` is called with no arguments. "
    ]
   },
   {


### PR DESCRIPTION
Two changes occured in Mojo 2024.1.0 which made some code in this notebook deprecated:
* Using `let` now raises a warning. We should use `var` instead.
* Initializers for `@register_passable` values can (and should!) now be specified with inout self arguments just like memory-only types.

See the changelog here: https://docs.modular.com/mojo/changelog#v241-2024-02-29


We currently show deprecated syntax in the notebook in the documentation. See https://docs.modular.com/mojo/notebooks/BoolMLIR#compile-time-constants