### PR TITLE
[Examples] Run `mojo format` on the examples

### DIFF
--- a/examples/mandelbrot.mojo
+++ b/examples/mandelbrot.mojo
@@ -88,9 +88,7 @@ fn main() raises:
         for row in range(height):
             worker(row)
 
-    var vectorized = benchmark.run[bench[simd_width]](
-        max_runtime_secs=0.5
-    ).mean()
+    var vectorized = benchmark.run[bench[simd_width]](max_runtime_secs=0.5).mean()
     print("Number of threads:", num_logical_cores())
     print("Vectorized:", vectorized, "s")
 

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -145,8 +145,7 @@ fn matmul_tiled(inout C: Matrix, A: Matrix, B: Matrix):
                     C.store(
                         m,
                         n + x,
-                        C.load[nelts](m, n + x)
-                        + A[m, k] * B.load[nelts](k, n + x),
+                        C.load[nelts](m, n + x) + A[m, k] * B.load[nelts](k, n + x),
                     )
 
                 vectorize[dot, nelts, size=tile_x]()
@@ -170,8 +169,7 @@ fn matmul_unrolled(inout C: Matrix, A: Matrix, B: Matrix):
                     C.store(
                         m,
                         n + x,
-                        C.load[nelts](m, n + x)
-                        + A[m, k] * B.load[nelts](k, n + x),
+                        C.load[nelts](m, n + x) + A[m, k] * B.load[nelts](k, n + x),
                     )
 
                 alias unroll_factor = tile_x // nelts

--- a/examples/nbody.mojo
+++ b/examples/nbody.mojo
@@ -89,11 +89,7 @@ fn energy(bodies: StaticTuple[NUM_BODIES, Planet]) -> Float64:
     @unroll
     for i in range(NUM_BODIES):
         var body_i = bodies[i]
-        e += (
-            0.5
-            * body_i.mass
-            * ((body_i.velocity * body_i.velocity).reduce_add())
-        )
+        e += 0.5 * body_i.mass * ((body_i.velocity * body_i.velocity).reduce_add())
 
         for j in range(NUM_BODIES - i - 1):
             var body_j = bodies[j + i + 1]
@@ -174,9 +170,7 @@ fn bench():
         ),
         5.15138902046611451e-05 * SOLAR_MASS,
     )
-    var system = StaticTuple[NUM_BODIES, Planet](
-        Sun, Jupiter, Saturn, Uranus, Neptune
-    )
+    var system = StaticTuple[NUM_BODIES, Planet](Sun, Jupiter, Saturn, Uranus, Neptune)
     offset_momentum(system)
 
     print("Energy of System:", energy(system))


### PR DESCRIPTION
Soon, CI will enforce linting and formatting on any changed mojo files in prep for open sourcing the Standard Library.  So, go ahead and ensure the existing examples files adhere to `mojo format` from top-of-tree.

Produced by:
```
git ls-files '*.mojo' | xargs mojo format
```