### PR TITLE
Fix md: use var instead of let

### DIFF
--- a/docs/manual/packages.md
+++ b/docs/manual/packages.md
@@ -51,7 +51,7 @@ that's in the same directory as `mymodule.mojo`:
 from mymodule import MyPair
 
 fn main():
-    let mine = MyPair(2, 4)
+    var mine = MyPair(2, 4)
     mine.dump()
 ```
 
@@ -62,7 +62,7 @@ through the module name. For example:
 import mymodule
 
 fn main():
-    let mine = mymodule.MyPair(2, 4)
+    var mine = mymodule.MyPair(2, 4)
     mine.dump()
 ```
 
@@ -72,7 +72,7 @@ You can also create an alias for an imported member with `as`, like this:
 import mymodule as my
 
 fn main():
-    let mine = my.MyPair(2, 4)
+    var mine = my.MyPair(2, 4)
     mine.dump()
 ```
 
@@ -124,7 +124,7 @@ name like this:
 from mypackage.mymodule import MyPair
 
 fn main():
-    let mine = MyPair(2, 4)
+    var mine = MyPair(2, 4)
     mine.dump()
 ```
 


### PR DESCRIPTION
Use `var` instead of `let`in `packages.md` file.

The reason is as follows:

> Mojo 24.1 removed support for let from the compiler IR (but it still parses let for migration), subsequent releases will remove the let keyword entirely.

Quote from https://github.com/modularml/mojo/discussions/1456#discussioncomment-8672522.

