### PR TITLE
[CI] Explicitly specify `types:` under PR section

### DIFF
--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -1,7 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
 name: Build and Test Mojo OSS
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test-pre-submit:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,7 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
 name: Test Examples
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
To ensure the workflow triggers on all types of status changes under the `pull_request` trigger, explicitly specify all the state changes.

While here, go ahead and add our open-source license to the top of each workflow.