### PR TITLE
[CI] Specify SHA in use of `paths-filter` action

### DIFF
--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -16,6 +16,7 @@ name: Build and Test Mojo OSS
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   test-pre-submit:
@@ -36,7 +37,7 @@ jobs:
           mojo --version
 
       - name: Filter files changed
-        uses: dorny/paths-filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:
           # Enable listing of files matching each filter.


### PR DESCRIPTION
The OSS workflow got broken in
https://github.com/modularml/mojo/commit/cb2144b80bfbe0a23536ebba996217d8facaa857 since the `uses:` grammar requires a ref or version.

Example CI failure:
```
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```

from https://github.com/modularml/mojo/actions/runs/8309422015

Fix this by explicitly specifying the latest tagged release of the `paths-filter` action.

While here, go ahead and add a `workflow_dispatch` trigger so this workflow can be manually run on a given branch.