### PR TITLE
[CI] Skip `setup-python` step

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -43,11 +43,6 @@ jobs:
           modular auth examples
           modular install mojo
 
-      - name: Setup python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
-        with:
-          python-version: 3.12
-
       - name: Install build tools
         run: |
           wget https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
The `ubuntu-latest` Docker image already comes with Python 3.10 installed.  See the
[README](https://github.com/actions/runner-images/blob/4224f365e0fb518e4eb80364c5f2f7716578ea0a/images/ubuntu/Ubuntu2204-Readme.md) for the GitHub Docker image corresponding to `ubuntu-latest`.  Since we're not too privy on the exact Python version, just use the default.