### PR TITLE
[CI] Add workflow permissions

### DIFF
--- a/.github/workflows/buildAndTestMojoOSS.yml
+++ b/.github/workflows/buildAndTestMojoOSS.yml
@@ -18,6 +18,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-pre-submit:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,6 +18,10 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a `permissions` section to all workflow files to allow third-party GitHub actions to have read permissions.  This will fix the issue where the `dorny/paths-filter` step doesn't have proper read permissions to query the file list modified in a pull request, resulting in a hard error from the GitHub APIs it uses.