### PR TITLE
[CI][Examples] Use `nightly/mojo` in workflow and examples

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -40,12 +40,12 @@ jobs:
         run: |
           curl -s https://get.modular.com | sh -
 
-      - name: Install stable Mojo compiler
+      - name: Install nightly Mojo compiler
         run: |
           # The <auth_token> of "examples" is arbitrary but something
           # needs to be provided.
           modular auth examples
-          modular install mojo
+          modular install nightly/mojo
 
       - name: Install build tools
         run: |
@@ -69,5 +69,5 @@ jobs:
       - name: Run examples
         run: |
           export MODULAR_HOME="/home/runner/.modular"
-          export PATH="/home/runner/.modular/pkg/packages.modular.com_mojo/bin:$PATH"
+          export PATH="/home/runner/.modular/pkg/packages.modular.com_nightly_mojo/bin:$PATH"
           ./examples/run-examples.sh

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -45,12 +45,25 @@ config.test_source_root = Path(__file__).parent.resolve()
 # Substitute %mojo for just `mojo` itself.
 config.substitutions.insert(0, ("%mojo", "mojo"))
 
+pre_built_packages_path = (
+    Path(os.environ["MODULAR_HOME"])
+    / "pkg"
+    / "packages.modular.com_nightly_mojo"
+    / "lib"
+    / "mojo"
+)
+
+os.environ["MODULAR_MOJO_NIGHTLY_IMPORT_PATH"] = (
+    f"{build_root},{pre_built_packages_path}"
+)
+
 # Pass through several environment variables
 # to the underlying subprocesses that run the tests.
 lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.with_system_environment(
     [
         "MODULAR_HOME",
+        "MODULAR_MOJO_NIGHTLY_IMPORT_PATH",
         "PATH",
     ]
 )


### PR DESCRIPTION
Install the `nightly/mojo` package and use it in the examples workflow. Additionally, specify to use the nightly compiler and pre-built packages in the `examples/lit.cfg.py`.