### PR TITLE
[CI] Run standard library tests

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-name: Test Examples
+name: Standard Library tests and examples
 
 on:
   pull_request:
@@ -66,8 +66,9 @@ jobs:
 
           python3 -m pip install lit
 
-      - name: Run examples
+      - name: Run standard library tests and examples
         run: |
           export MODULAR_HOME="/home/runner/.modular"
           export PATH="/home/runner/.modular/pkg/packages.modular.com_nightly_mojo/bin:$PATH"
+          ./stdlib/scripts/run-tests.sh
           ./examples/run-examples.sh


### PR DESCRIPTION
Currently, `examples.yml` only runs the examples, which was convenient for launching today.  Now that we've shipped the standard library though, augment the workflow file to also run the standard library tests.

While we're here, rename the name of the file, step, and name of the job to better reflect reality that this file is used to run the standard library tests and the examples now.