### PR TITLE
[mojo-stdlib] Export `InlinedFixedVector` from `collections`

### DIFF
--- a/stdlib/src/collections/__init__.mojo
+++ b/stdlib/src/collections/__init__.mojo
@@ -16,4 +16,7 @@ from .dict import Dict, KeyElement
 from .list import List
 from .optional import Optional, OptionalReg
 from .set import Set
-from .vector import CollectionElement
+from .vector import (
+    CollectionElement,
+    InlinedFixedVector,
+)


### PR DESCRIPTION
Exports InlinedFixedVector form collections

Signed-off-by: Farhan Ali Raza <farhanalirazaazeemi@gmail.com>

