### PR TITLE
feature: Add minimal initial CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for the Mojo repository
+
+# Standard Library
+/stdlib/ @modularml/mojo-standard-library

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,11 @@
 # Code owners for the Mojo repository
 
-# Standard Library
-/stdlib/ @modularml/mojo-standard-library
+# Standard Library Sources
+/stdlib/       @modularml/mojo-standard-library
+
+# Documentation
+/docs/         @scottamain @arthurevans
+/stdlib/docs/  @scottamain @arthurevans
+
+# Examples
+/examples/     @jackos


### PR DESCRIPTION
This adds a minimal CODEOWNERS file, for the new `/stdlib/` directory.