### PR TITLE
[Utils] Add `.DS_Store` to `.gitignore` for Mac developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# MacOS
 .DS_Store


### PR DESCRIPTION
It is nice to ignore `.DS_Store` for Mac developers.