### PR TITLE
[docs] Fix wrong `mojo format` command, add `-l 80`.

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -111,7 +111,7 @@ jobs:
           mojo format ${{ steps.filter.outputs.mojo_files }} -l 80
           # Check if any lines were formatted.  If any were, fail this step.
           if [ $(git diff | wc -l) -gt 0 ]; then
-            echo -e "\nError! Mojo code not formatted. Run `mojo format` ...\n"
+            echo -e "\nError! Mojo code not formatted. Run `mojo format -l 80` ...\n"
             echo -e "\nFiles that don't match the proper formatting:\n"
             git diff --name-only
             echo -e "\nFull diff:\n"

--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -112,14 +112,14 @@ Otherwise, CI will fail in its lint and formatting checks.  The `mojo` compiler
 provides a `format` command.  So, you can format your changes like so:
 
 ```bash
-mojo format <file1> <file2> ...
+mojo format -l 80 <file1> <file2> ...
 ```
 
 You can also do this before submitting a pull request by running it on the
 relevant files changed compared to the remote:
 
 ```bash
-git diff origin/main --name-only -- '*.mojo' | xargs mojo format
+git diff origin/main --name-only -- '*.mojo' | xargs mojo format -l 80
 ```
 
 You can also consider setting up your editor to automatically format
@@ -327,7 +327,7 @@ Total Discovered Tests: 1
 
 Success! Now we have a test for our new function.
 
-The last step is to [run mojo format](#formatting-changes) on all the files.
+The last step is to [run `mojo format -l 80`](#formatting-changes) on all the files.
 
 ### Raising a PR
 

--- a/stdlib/docs/style-guide.md
+++ b/stdlib/docs/style-guide.md
@@ -40,13 +40,14 @@ It adjusts indentation, spacing, and line breaks, making code more readable and
 consistent.
 
 ```bash
-> mojo format example.mojo
+> mojo format -l 80 example.mojo
 All done! ✨ 🍰 ✨
 1 file left unchanged.
 ```
 
 Unless otherwise noted, Mojo standard library code should follow the formatting
-produced by `mojo format`.
+produced by `mojo format -l 80`. Note that the default `mojo format` command is not enough.
+You need to specify that there is a limit of 80 characters per line with `-l 80`.
 
 #### Whitespace
 


### PR DESCRIPTION
The `mojo format` [command in the CI](https://github.com/modularml/mojo/blob/nightly/.github/workflows/standard_library_tests_and_examples.yml#L111) applies a limit of 80 chars with `-l 80`. This is not documented anywhere, resulting in broken formatting in pull requests. This PR fixes this issue.