### PR TITLE
[stdlib] Do not merge, `@always_inline` bug reproducer

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -513,7 +513,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             rebind[Scalar[type]](self).value
         )
 
-    @always_inline
+    # @always_inline
     fn __str__(self) -> String:
         """Get the SIMD as a string.
 

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -657,6 +657,10 @@ def test_mul_with_overflow():
     )
 
 
+def test_uint32_max():
+    assert_equal(str(UInt32.MAX), "4294967295")
+
+
 def main():
     test_cast()
     test_simd_variadic()
@@ -674,3 +678,4 @@ def main():
     test_add_with_overflow()
     test_sub_with_overflow()
     test_mul_with_overflow()
+    test_uint32_max()


### PR DESCRIPTION
Showing how `@always_inline` affect the bug #2353 
Uncomment `@always_inline` and you'll observe that the tests aren't passing anymore (with a beautiful error message terminated too early at that)

Here is the error message if you uncomment `@always_inline`:

```
$ ./stdlib/scripts/run-tests.sh && lit -sv stdlib/test/builtin/test_simd.mojo
Creating build directory for building the stdlib running the tests in.
Packaging up the Standard Library.
Successfully created /projects/open_source/mojo/build/stdlib.mojopkg
Packaging up the test_utils.
FAIL: Mojo Standard Library :: builtin/test_simd.mojo (82 of 82)
******************** TEST 'Mojo Standard Library :: builtin/test_simd.mojo' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
Unhandled exception caught during execution: AssertionError: `left == right` comparison failed:
   left: 429496729

--
Command Output (stderr):
--
RUN: at line 13: mojo -debug-level full /projects/open_source/mojo/stdlib/test/builtin/test_simd.mojo
+ mojo -debug-level full /projects/open_source/mojo/stdlib/test/builtin/test_simd.mojo
mojo: error: execution exited with a non-zero result: 1

--

********************
********************
Failed Tests (1):
  Mojo Standard Library :: builtin/test_simd.mojo


Testing Time: 5.31s

Total Discovered Tests: 82
  Unsupported:  8 (9.76%)
  Passed     : 73 (89.02%)
  Failed     :  1 (1.22%)
```