### PR TITLE
 Issue #2487: Make message argument in `assert_true/assert_false/...`  keyword only.

### DIFF
--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -70,7 +70,7 @@ fn _assert_error[T: Stringable](msg: T, loc: _SourceLocation) -> String:
 
 @always_inline
 fn assert_true(
-    val: Bool, msg: String = "condition was unexpectedly False"
+    val: Bool, *, msg: String = "condition was unexpectedly False"
 ) raises:
     """Asserts that the input value is True. If it is not then an
     Error is raised.
@@ -88,7 +88,7 @@ fn assert_true(
 
 @always_inline
 fn assert_false(
-    val: Bool, msg: String = "condition was unexpectedly True"
+    val: Bool, *, msg: String = "condition was unexpectedly True"
 ) raises:
     """Asserts that the input value is False. If it is not then an Error is
     raised.
@@ -112,7 +112,7 @@ trait Testable(EqualityComparable, Stringable):
 
 
 @always_inline
-fn assert_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
+fn assert_equal[T: Testable](lhs: T, rhs: T, *, msg: String = "") raises:
     """Asserts that the input values are equal. If it is not then an Error
     is raised.
 
@@ -133,7 +133,7 @@ fn assert_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
 
 # TODO: Remove the String and SIMD overloads once we have more powerful traits.
 @always_inline
-fn assert_equal(lhs: String, rhs: String, msg: String = "") raises:
+fn assert_equal(lhs: String, rhs: String, *, msg: String = "") raises:
     """Asserts that the input values are equal. If it is not then an Error
     is raised.
 
@@ -175,7 +175,7 @@ fn assert_equal[
 
 
 @always_inline
-fn assert_not_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
+fn assert_not_equal[T: Testable](lhs: T, rhs: T, *, msg: String = "") raises:
     """Asserts that the input values are not equal. If it is not then an
     Error is raised.
 
@@ -197,7 +197,7 @@ fn assert_not_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
 
 
 @always_inline
-fn assert_not_equal(lhs: String, rhs: String, msg: String = "") raises:
+fn assert_not_equal(lhs: String, rhs: String, *, msg: String = "") raises:
     """Asserts that the input values are not equal. If it is not then an
     an Error is raised.
 
@@ -282,8 +282,7 @@ fn assert_almost_equal[
 
 
 fn _assert_equal_error(
-    lhs: String, rhs: String, msg: String, loc: _SourceLocation
-) -> String:
+    lhs: String, rhs: String, loc: _SourceLocation, *, msg: String = "") -> String:
     var err = (
         "`left == right` comparison failed:\n   left: "
         + lhs
@@ -296,8 +295,7 @@ fn _assert_equal_error(
 
 
 fn _assert_not_equal_error(
-    lhs: String, rhs: String, msg: String, loc: _SourceLocation
-) -> String:
+    lhs: String, rhs: String, loc: _SourceLocation, *, msg: String := "") -> String:
     var err = (
         "`left != right` comparison failed:\n   left: "
         + lhs

--- a/stdlib/test/builtin/test_hash.mojo
+++ b/stdlib/test/builtin/test_hash.mojo
@@ -43,7 +43,7 @@ def test_hash_byte_array():
     num_same += same_low_bits(hash("b".data(), 1), hash("d".data(), 1))
     num_same += same_low_bits(hash("c".data(), 1), hash("d".data(), 1))
 
-    assert_true(num_same < 2, "too little entropy in hash fn low bits")
+    assert_true(num_same < 2, msg="too little entropy in hash fn low bits")
 
 
 def _test_hash_int_simd[type: DType](bits: Int = 4):
@@ -67,7 +67,7 @@ def _test_hash_int_simd[type: DType](bits: Int = 4):
     num_same += same_low_bits(_hash_simd(b), _hash_simd(d), bits)
     num_same += same_low_bits(_hash_simd(c), _hash_simd(d), bits)
 
-    assert_true(num_same < 2, "too little entropy in hash fn low bits")
+    assert_true(num_same < 2, msg="too little entropy in hash fn low bits")
 
 
 def test_hash_simd():

--- a/stdlib/test/os/test_remove.mojo
+++ b/stdlib/test/os/test_remove.mojo
@@ -30,7 +30,7 @@ fn create_file_and_test_delete_string[
 
     assert_true(exists(filename))
     func(filename)
-    assert_false(exists(filename), "test with '" + name + "' failed")
+    assert_false(exists(filename), msg="test with '" + name + "' failed")
 
 
 fn create_file_and_test_delete_path[
@@ -45,7 +45,7 @@ fn create_file_and_test_delete_path[
 
     assert_true(exists(filepath))
     func(filepath)
-    assert_false(exists(filepath), "test with '" + name + "' failed")
+    assert_false(exists(filepath), msg="test with '" + name + "' failed")
 
 
 fn test_remove() raises:

--- a/stdlib/test/os/test_remove.mojo
+++ b/stdlib/test/os/test_remove.mojo
@@ -26,7 +26,7 @@ fn create_file_and_test_delete_string[
         with open(filename, "w"):
             pass
     except:
-        assert_true(False, "Failed to create file for test")
+        assert_true(False, msg="Failed to create file for test")
 
     assert_true(exists(filename))
     func(filename)
@@ -41,7 +41,7 @@ fn create_file_and_test_delete_path[
         with open(filepath.__fspath__(), "w"):
             pass
     except:
-        assert_true(False, "Failed to create file for test")
+        assert_true(False, msg="Failed to create file for test")
 
     assert_true(exists(filepath))
     func(filepath)

--- a/stdlib/test/pathlib/test_pathlib.mojo
+++ b/stdlib/test/pathlib/test_pathlib.mojo
@@ -48,9 +48,9 @@ def test_path():
 def test_path_exists():
     print("== test_path_exists")
 
-    assert_true(Path(__source_location().file_name).exists(), "does not exist")
+    assert_true(Path(__source_location().file_name).exists(), msg="does not exist")
 
-    assert_false((Path() / "this_path_does_not_exist.mojo").exists(), "exists")
+    assert_false((Path() / "this_path_does_not_exist.mojo").exists(), msg="exists")
 
 
 def test_path_isdir():


### PR DESCRIPTION
Changelog:
- I added a `*` to separate the variadic and keyword only arguments in the file `stdlib/src/testing/testing.mojo`
- Changed the call sites for functions `assert_true` and `assert_false` from `assert_true(val, msg)` to `assert_true(val, msg=msg)`

Let me know if I need to change any more occurrences / do something else.