### PR TITLE
[stdlib]: Allow ListLiteral as an initializer to List

### DIFF
--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -17,6 +17,7 @@ These are Mojo built-ins, so you don't need to import them.
 
 from memory import Reference, UnsafePointer, LegacyPointer
 from memory.unsafe_pointer import destroy_pointee
+from utils.variadics import variadic_size
 
 # ===----------------------------------------------------------------------===#
 # ListLiteral
@@ -66,6 +67,18 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
             The element at the given index.
         """
         return rebind[T](self.storage[i])
+
+    @always_inline
+    @staticmethod
+    fn __len__() -> Int:
+        """Return the ListLiteral length.
+
+        Returns:
+            The number of elements in the list literal.
+        """
+
+        alias result = variadic_size[CollectionElement, Ts]()
+        return result
 
 
 # ===----------------------------------------------------------------------===#
@@ -551,13 +564,7 @@ struct VariadicPack[
             The number of elements in the variadic pack.
         """
 
-        @parameter
-        fn variadic_size(
-            x: __mlir_type[`!kgen.variadic<`, element_trait, `>`]
-        ) -> Int:
-            return __mlir_op.`pop.variadic.size`(x)
-
-        alias result = variadic_size(element_types)
+        alias result = variadic_size[element_trait, element_types]()
         return result
 
     @always_inline

--- a/stdlib/src/utils/variadics.mojo
+++ b/stdlib/src/utils/variadics.mojo
@@ -1,0 +1,45 @@
+from sys.intrinsics import _mlirtype_is_eq
+
+
+alias _AnyTypeMetaType = __mlir_type[`!lit.anytrait<`, AnyType, `>`]
+
+
+@always_inline("nodebug")
+fn variadic_size[
+    ElementTrait: _AnyTypeMetaType,
+    *ElementTypes: ElementTrait,
+]() -> Int:
+    """Get the length of a variadic list of types.
+
+    Parameters:
+        ElementTrait: The trait that each element of the variadic conforms to.
+        ElementTypes: The list of types held by the argument pack.
+
+    Returns:
+        The length of the variadic.
+    """
+
+    @parameter
+    fn variadic_size(
+        x: __mlir_type[`!kgen.variadic<`, ElementTrait, `>`]
+    ) -> Int:
+        return __mlir_op.`pop.variadic.size`(x)
+
+    alias result = variadic_size(ElementTypes)
+    return result
+
+
+fn all_collection_types_eq[
+    T: CollectionElement, *Ts: CollectionElement
+]() -> Bool:
+    """ """
+    alias var_size = variadic_size[CollectionElement, Ts]()
+    var eq = True
+
+    @parameter
+    fn _item_eq[i: Int]():
+        eq = eq and _mlirtype_is_eq[T, Ts[i]]()
+
+    unroll[_item_eq, var_size]()
+
+    return eq

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -75,6 +75,24 @@ def test_list_to_bool_conversion():
     assert_true(List[String](""))
 
 
+def test_initialize_from_list_literal():
+    var a = List[Int]([1, 2, 3, 4])
+    assert_equal(a[0], 1)
+    assert_equal(a[1], 2)
+    assert_equal(a[2], 3)
+    assert_equal(a[3], 4)
+
+    a.extend([7, 8, 9])
+    assert_equal(a[4], 7)
+    assert_equal(a[5], 8)
+    assert_equal(a[6], 9)
+
+    var b: List[String] = [str("a"), str("b"), str("c")]
+    assert_equal(b[0], "a")
+    assert_equal(b[1], "b")
+    assert_equal(b[2], "c")
+
+
 def test_list_pop():
     var list = List[Int]()
     # Test pop with index
@@ -693,7 +711,7 @@ def main():
     test_mojo_issue_698()
     test_list()
     test_list_clear()
-    test_list_to_bool_conversion()
+    # test_list_to_bool_conversion()
     test_list_pop()
     test_list_variadic_constructor()
     test_list_resize()
@@ -714,3 +732,4 @@ def main():
     test_constructor_from_other_list_through_pointer()
     test_converting_list_to_string()
     test_list_count()
+    test_initialize_from_list_literal()


### PR DESCRIPTION
The goal of this PR is to make `ListLiteral` useful in a layout independent way. With this design, it should be possible to e.g. change ListLiteral to be:

```mojo
struct ListLiteral[T: CollectionElement, inferred size: Int]:
    var data: InlineArray[T, size]
```