### PR TITLE
Update types.ipynb

### DIFF
--- a/docs/manual/types.ipynb
+++ b/docs/manual/types.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "- Space between consecutive numbers. The space between consecutive numbers is\n",
     "  variable across the range of a floating-point number format. For numbers close\n",
-    "  to zero, the distance between consecutive numbers is very small. is For large\n",
+    "  to zero, the distance between consecutive numbers is very small. For large\n",
     "  positive and negative numbers, the space between consecutive numbers is\n",
     "  greater than 1, so it may not be possible to represent consecutive integers.\n",
     "\n",


### PR DESCRIPTION
Removed extra "is" at start of sentence in paragraph describing the space between consecutive floating point numbers.