### PR TITLE
[stdlib] Add `FileHandle.__iter__()` with newline as separator

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -450,6 +450,44 @@ struct FileHandle:
         """The function to call when entering the context."""
         return self^
 
+    fn __iter__(self) raises -> List[String]:
+        """Iterate over lines in the file separated by the
+        newline character: \\n.
+
+        Returns:
+            A List of the file lines.
+
+        Examples:
+
+        ```mojo
+        var f = open("/tmp/example.txt", "r")
+        # TODO: this is ugly stil, since List doesn't implement __next__
+        # but once we have generators the problem should go away
+        for line in f.__iter__().__iter__():
+            print(line[])
+        ```
+        """
+        # TODO: when generators are implemented this should be something like
+        # alias eol = String("\n").as_bytes()[0]
+        # var content = self.read_bytes()
+        # var i = 0
+        # while i < content.size:
+        #     var new_i = content[i:].index(eol).or_else(content.size)
+        #     yield StringRef(content[i:new_i])
+        #     i = new_i
+        return self.read().split("\n")
+
+    fn __reversed__(self) raises -> List[String]:
+        """Iterate backwards over lines in the file separated by the
+        newline character: \\n.
+
+        Returns:
+            A reversed List of the file line elements.
+        """
+        var content = self.read().split("\n")
+        content.reverse()
+        return content
+
 
 fn open(path: String, mode: String) raises -> FileHandle:
     """Opens the file specified by path using the mode provided, returning a

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -212,6 +212,31 @@ def test_file_read_to_dtype_pointer():
     )
 
 
+def test_file_iter():
+    var TMP_FILE = Path(TEMP_FILE_DIR) / "dummy_newline_iterator.txt"
+    alias textitems = (
+        "Lorem",
+        "ipsum",
+        "dolor",
+        "sit",
+        "namet,",
+        "consectetur",
+        "adipiscing elit.",
+    )
+    alias text2 = "Lorem\nipsum\ndolor\nsit\namet,\nconsectetur\nadipiscing elit."
+    alias text1 = "Lorem\nipsum\ndolor\nsit\namet,\nconsectetur\nadipiscing elit.\n"
+    for text in List(text1, text2):
+        with open(TMP_FILE, "w") as f:
+            f.write(text1)
+        var f_r = open(TMP_FILE, "r")
+        var counter = 0
+        for line in f_r.__iter__().__iter__():
+            assert_equal(line[], textitems[counter])
+            counter += 1
+        f_r.close()
+        assert_equal(counter, len(textitems))
+
+
 def main():
     test_file_read()
     test_file_read_multi()
@@ -224,3 +249,4 @@ def main():
     test_file_write()
     test_file_write_again()
     test_file_read_to_dtype_pointer()
+    test_file_iter()

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -214,7 +214,7 @@ def test_file_read_to_dtype_pointer():
 
 def test_file_iter():
     var TMP_FILE = Path(TEMP_FILE_DIR) / "dummy_newline_iterator.txt"
-    alias textitems = (
+    alias textitems = List(
         "Lorem",
         "ipsum",
         "dolor",


### PR DESCRIPTION
To add pythonesque functionality

For now it returns a `List[String]` which doesn't implment the `__next__` method so its `__iter__ `needs to be manually called
```mojo
var f = open("/tmp/example.txt", "r")
for line in f.__iter__().__iter__():
    print(line[])
```
needs generators to be able to be called directly once.

The future implementation could look something like
```mojo
alias eol = String("\n").as_bytes()[0]
var content = self.read_bytes()
var i = 0
while i < content.size:
    var new_i = content[i:].index(eol).or_else(content.size)
    yield StringRef(content[i:new_i])
    i = new_i
```