### PR TITLE
[stdlib] use `__refitem__` in List

### DIFF
--- a/stdlib/src/builtin/dtype.mojo
+++ b/stdlib/src/builtin/dtype.mojo
@@ -727,7 +727,7 @@ fn _get_runtime_dtype_size(type: DType) -> Int:
     statically known dtypes. Instead, we have to perform a dispatch to
     determine the size of the dtype.
     """
-    alias type_list = List[DType](
+    alias type_list = StaticTuple[DType, 16](
         DType.bool,
         DType.int8,
         DType.uint8,

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -96,7 +96,7 @@ struct _DictEntryIter[
             else:
                 debug_assert(self.index >= 0, "dict iter bounds")
 
-            var opt_entry_ref = self.src[]._entries.__get_ref(self.index)
+            var opt_entry_ref = self.src[]._entries.__refitem__(self.index)
             if opt_entry_ref[]:
 
                 @parameter
@@ -602,7 +602,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         var index: Int
         found, slot, index = self._find_index(hash, key)
         if found:
-            var ev = self._entries.__get_ref(index)[]
+            var ev = self._entries[index]
             debug_assert(ev.__bool__(), "entry in index must be full")
             return ev.value()[].value
         return None
@@ -630,7 +630,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         found, slot, index = self._find_index(hash, key)
         if found:
             self._set_index(slot, Self.REMOVED)
-            var entry = self._entries.__get_ref(index)[]
+            var entry = self._entries[index]
             self._entries[index] = None
             self.size -= 1
             debug_assert(entry.__bool__(), "entry in index must be full")
@@ -752,7 +752,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
             elif index == Self.REMOVED:
                 return (False, slot, self._n_entries)
             else:
-                var ev = self._entries.__get_ref(index)[]
+                var ev = self._entries[index]
                 debug_assert(ev.__bool__(), "entry in index must be full")
                 var entry = ev.value()[]
                 if hash == entry.hash and key == entry.key:
@@ -778,7 +778,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._entries = self._new_entries(self._reserved)
 
         for i in range(len(old_entries)):
-            var entry = old_entries.__get_ref(i)[]
+            var entry = old_entries[i]
             if entry:
                 self._insert(entry.value()[])
 
@@ -786,10 +786,10 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._index = _DictIndex(self._reserved)
         var right = 0
         for left in range(self.size):
-            while not self._entries.__get_ref(right)[]:
+            while not self._entries[right]:
                 right += 1
                 debug_assert(right < self._reserved, "Invalid dict state")
-            var entry = self._entries.__get_ref(right)[]
+            var entry = self._entries[right]
             debug_assert(entry.__bool__(), "Logic error")
             var slot = self._find_empty_index(entry.value()[].hash)
             self._set_index(slot, left)

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -551,8 +551,8 @@ def test_list_explicit_copy():
     var list = List[CopyCounter]()
     list.append(CopyCounter())
     var list_copy = List(list)
-    assert_equal(0, list.__get_ref(0)[].copy_count)
-    assert_equal(1, list_copy.__get_ref(0)[].copy_count)
+    assert_equal(0, list[0].copy_count)
+    assert_equal(1, list_copy[0].copy_count)
 
     var l2 = List[Int]()
     for i in range(10):

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -357,20 +357,20 @@ def test_list_index():
     assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 60)
+        _ = __type_of(test_list_a).index(test_list_a, 60)
 
     # Tests With Start Parameter
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 30, start=3)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=3)
     with assert_raises(
         contains=(
             "Given 'start' parameter (5) is out of range. List only has 5"
             " elements."
         )
     ):
-        __type_of(test_list_a).index(test_list_a, 30, start=5)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=5)
 
     # Tests With Start and End Parameters
     assert_equal(
@@ -380,19 +380,19 @@ def test_list_index():
         __type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2
     )
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
     # Tests With End Parameter Only
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=3), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=-2), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 30, end=1)
+        _ = __type_of(test_list_a).index(test_list_a, 30, end=1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 30, end=2)
+        _ = __type_of(test_list_a).index(test_list_a, 30, end=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 60, end=50)
+        _ = __type_of(test_list_a).index(test_list_a, 60, end=50)
 
     # Edge Cases and Special Conditions
     assert_equal(
@@ -402,22 +402,22 @@ def test_list_index():
         __type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0
     )
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(
         contains=(
             "Given 'start' parameter (5) is out of range. List only has 5"
             " elements."
         )
     ):
-        __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
+        _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
     with assert_raises(
         contains="Cannot find index of a value in an empty list."
     ):
-        __type_of(List[Int]()).index(List[Int](), 10)
+        _ = __type_of(List[Int]()).index(List[Int](), 10)
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)
 
@@ -549,7 +549,7 @@ def test_2d_dynamic_list():
 
 def test_list_explicit_copy():
     var list = List[CopyCounter]()
-    list.append(CopyCounter()^)
+    list.append(CopyCounter())
     var list_copy = List(list)
     assert_equal(0, list.__get_ref(0)[].copy_count)
     assert_equal(1, list_copy.__get_ref(0)[].copy_count)


### PR DESCRIPTION
attempts #2432.  Encountered a couple of issues: 

- #2543 when using List in an alias. Worked around by using a StaticTuple in place of List.  Was required in only one place.
- #2540 when using `vec[::1]` or any other Slice.  Can be worked around by `__getitem__(slice(...))` in many cases but I don't think we want to do that.  And that `slice` syntax requires the endpoints so it isn't a workaround in all cases.

For special attention during review, I changed explicit use of `__refitem__` in other modules like `Dict` to just use vanilla `foo[index]`. I think those calls existed to avoid copies which should be default behaviour with `__refitem__` wiring.  So `var ev = self._entries.__get_ref(index)[]` became `self.entries[index]`.  Where specific mutability and lifetimes were being passed I kept the longform use of `__refitem__`.