### PR TITLE
[docs] Add fix-ups to docs/changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,9 +19,8 @@ what we publish.
 ### ⭐️ New
 
 - Mojo has introduced `@parameter for`, a new feature for compile-time
-  programming. `@parameter for` defines a for loop where the sequence must be a
-  parameter value and the induction variables are also parameter values in that
-  sequence. For example:
+  programming. `@parameter for` defines a for loop where the sequence and the
+  induction values in the sequence must be parameter values. For example:
 
   ```mojo
   fn parameter_for[max: Int]():
@@ -36,10 +35,10 @@ what we publish.
   `break`, `continue`, etc.) and requires the sequence's `__iter__` method to
   return a `_StridedRangeIterator`. These restrictions will be lifted soon.
 
-- Mojo added support for the `inferred` passing kind on parameters. `inferred`
+- Mojo added support for the `inferred` parameter convention. `inferred`
   parameters must appear at the beginning of the parameter list and cannot be
-  explicitly specified by the user. This allows users to define functions with
-  dependent parameters to be called without the caller specifying all the
+  explicitly specified by the user. This allows programmers to define functions
+  with dependent parameters to be called without the caller specifying all the
   necessary parameters. For example:
 
   ```mojo
@@ -51,7 +50,7 @@ what we publish.
   ```
 
   In the above example, `Int32(42)` is passed directly into `value`, the first
-  non-inferred parameter. `dt` is inferred from the parameter itself to
+  non-inferred parameter. `dt` is inferred from the parameter itself to be
   `DType.int32`.
 
   This also works with structs. For example:
@@ -87,12 +86,12 @@ what we publish.
   ```
 
 - Mojo has changed how `def` arguments are processed.  Previously, by default,
-  arguments to a `def` were treated as `owned` convention, which makes a copy of
-  the value, enabling that value to be mutable in the callee.  This is "worked",
-  but was a major performance footgun, and required you to declare non-copyable
-  types as `borrowed` explicitly.  Now Mojo takes a different approach: it takes
-  the arguments as `borrowed` (consistent with `fn`s) but will make a local copy
-  of the value **only if the argument is mutated** on the body of the function.
+  arguments to a `def` were treated treated according to the `owned` convention,
+  which makes a copy of the value, enabling that value to be mutable in the callee.
+  This "worked", but was a major performance footgun, and required you to declare
+  non-copyable types as `borrowed` explicitly.  Now Mojo takes a different approach:
+  it takes the arguments as `borrowed` (consistent with `fn`s) but will make a local
+  copy of the value **only if the argument is mutated** in the body of the function.
   This improves consistency, performance, and ease of use.
 
 - `int()` can now take a string and a specified base to parse an integer from a
@@ -226,7 +225,7 @@ what we publish.
 - Added a new `Span` type for taking slices of contiguous collections.
   ([PR #2595](https://github.com/modularml/mojo/pull/2595) by [lsh](https://github.com/lsh))
 
-- Added new `as_bytes_slice()` methods to `String` and `StringLiteral`, which
+- Added a new `as_bytes_slice()` method to `String` and `StringLiteral`, which
   returns a `Span` of the bytes owned by the string.
 
 - Add new `ImmStaticLifetime` and `MutStaticLifetime` helpers
@@ -239,7 +238,7 @@ what we publish.
 - Debugger users can now set breakpoints on function calls in O0 builds even if
   the call has been inlined by the compiler.
 
-- The `os` module now provides functionalty for adding and removing directories
+- The `os` module now provides functionality for adding and removing directories
   using `mkdir` and `rmdir`.
     ([PR #2430](https://github.com/modularml/mojo/pull/2430) by [@artemiogr97](https://github.com/artemiogr97))
 
@@ -287,7 +286,7 @@ what we publish.
     ([PR #2673](https://github.com/modularml/mojo/pull/2673) by [@gabrieldemarmiesse](https://github.com/gabrieldemarmiesse))
 
 - Added the `Indexer` trait to denote types that implement the `__index__()`
-  method which allow these types to be accepted in common `__getitem__` and
+  method which allows these types to be accepted in common `__getitem__` and
   `__setitem__` implementations, as well as allow a new builtin `index` function
   to be called on them.
   ([PR #2685](https://github.com/modularml/mojo/pull/2685) by
@@ -358,7 +357,7 @@ what we publish.
   explicitly use `SIMD.reduce_and()` or `SIMD.reduce_or()`.
     ([PR #2502](https://github.com/modularml/mojo/pull/2502) by [@helehex](https://github.com/helehex))
 
-- `ListLiteral` and `Tuple` now only requires that element types be `Copyable`.
+- `ListLiteral` and `Tuple` now only require that element types be `Copyable`.
   Consequently, `ListLiteral` and `Tuple` are themselves no longer `Copyable`.
 
 - Continued transition to `UnsafePointer` and unsigned byte type for strings:


### PR DESCRIPTION
This PR adds a few typo/grammar fixes to `docs/changelog.md`:

- Changed "the sequence must be a parameter value and the induction variables are also parameter values in that sequence" to "the sequence and the induction values in the sequence must be parameter values"
- Changed "the `inferred` passing kind on parameters" to "the `inferred` parameter convention" (which is more consistent with the term "argument convention" already used by Mojo"
- Changed "specified by the user. This allows users" to "specified by the user. This allows programmers" ("user" was referring to both writers and users of functions)
- Changed "to `DType.int32`" to "to be `DType.int32`"
- Changed "treated as `owned` convention" to "treated according to the `owned` convention"
- Changed 'This is "worked"' to 'This "worked"'
- Changed "mutated on the body of the function" to "mutated in the body of the function"
- Changed "Added new `as_bytes_slice()` methods to `String` and `StringLiteral`" to "Added a new `as_bytes_slice()` method to `String` and `StringLiteral`"
- Changed "functionalty" to "functionality"
- Changed "method which allow" to "method which allows"
- Changed "`ListLiteral` and `Tuple` now only requires" to "`ListLiteral` and `Tuple` now only require"