### PR TITLE
[tools] Simplify doc validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         stages: [commit]
       - id: check-docstrings
         name: check-docstrings
-        entry: python3 ./stdlib/scripts/check-docstrings.py
+        entry: mojo doc --validate-doc-strings stdlib/src
         language: system
         pass_filenames: false
         stages: [commit]


### PR DESCRIPTION
Now that `mojo doc` command learned `--validate-doc-strings`, we don't need to have the wrapper script that inspects `stderr` that `mojo doc -diagnose-missing-doc-strings` previously used in the `check-docstrings.py`.

We'll update the docs in a separate PR since this `.pre-commit-config.yaml` isn't managed by Copybara.