### PR TITLE
[Examples] Fix plt figure dimensions in RayTracing example notebook

### DIFF
--- a/examples/notebooks/RayTracing.ipynb
+++ b/examples/notebooks/RayTracing.ipynb
@@ -311,7 +311,7 @@
         "    plt = Python.import_module(\"matplotlib.pyplot\")\n",
         "    colors = Python.import_module(\"matplotlib.colors\")\n",
         "    dpi = 32\n",
-        "    fig = plt.figure(1, [image.height // 10, image.width // 10], dpi)\n",
+        "    fig = plt.figure(1, [image.width // 10, image.height // 10], dpi)\n",
         "\n",
         "    plt.imshow(image.to_numpy_image())\n",
         "    plt.axis(\"off\")\n",


### PR DESCRIPTION
The figsize in plt.figure should be in (width, height). 
It was inverted, making the fig look like this:
![before](https://github.com/modularml/mojo/assets/102399121/dc609d7c-5bb6-4b3a-99ad-8fc3a8e01e69)

After swapping the dimension:
![after](https://github.com/modularml/mojo/assets/102399121/f6cc0835-a77e-4c46-a13b-e33f083fc60f)