### PR TITLE
[docker] ```AUTH_KEY``` arguments removed in ```examples/docker``` folder

### DIFF
--- a/examples/docker/Dockerfile.mojosdk
+++ b/examples/docker/Dockerfile.mojosdk
@@ -17,7 +17,7 @@
 
 # Example command line:
 # Use no-cache to force docker to rebuild layers of the image by downloading the SDK from the repos
-# ./build-image.sh --auth-key <your-modular-auth-key>
+# ./build-image.sh --mojo-version
 #
 
 FROM ubuntu:20.04
@@ -51,11 +51,8 @@ RUN pip install \
         ipywidgets
 
 # A random default token
-ARG AUTH_KEY=5ca1ab1e
-ENV AUTH_KEY=$AUTH_KEY
 
-RUN curl https://get.modular.com | sh - && \
-    modular auth $AUTH_KEY 
+RUN curl -s https://get.modular.com | sh -
 RUN modular install mojo
 
 ARG MODULAR_HOME="/root/.modular"

--- a/examples/docker/build-image.sh
+++ b/examples/docker/build-image.sh
@@ -15,21 +15,15 @@ set -e
 
 # Usage
 # ==========
-# ./build-image.sh --auth-key <your-auth-key>
+# ./build-image.sh --mojo-version
 #
 
 # CLI option handling code
-DEFAULT_KEY=5ca1ab1e
-user_key=${user_key:=${DEFAULT_KEY}}
 mojo_ver=${mojo_ver:=0.3}
 container_engine=${container_engine:=docker}
 extra_cap=${extra_cap:=}
 while [ $# -gt 0 ]; do
         case "$1" in
-                --auth-key)
-                        user_key="$2"
-                        shift
-                        ;;
                 --use-podman)
                         container_engine=podman
                         extra_cap="--cap-add SYS_PTRACE"
@@ -45,18 +39,9 @@ while [ $# -gt 0 ]; do
         shift $(( $# > 0 ? 1 : 0 ))
 done
 
-check_options() {
-        if [ "${user_key}" = "${DEFAULT_KEY}" ]; then
-                echo "# No auth token specified; use --auth-key to specify your token"
-                exit 1
-        fi
-}
-
 build_image() {
-        check_options
         echo "# Building image with ${container_engine}..."
         ${container_engine} build --no-cache ${extra_cap} \
-           --build-arg AUTH_KEY=${user_key} \
            --pull -t modular/mojo-v${mojo_ver}-`date '+%Y%d%m-%H%M'` \
            --file Dockerfile.mojosdk .
 }

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     build :
       context: .
       dockerfile: Dockerfile.mojosdk
-      args:
-        - AUTH_KEY=1Auth_token
       no_cache : true
     ports:
       - 8888:8888 


### PR DESCRIPTION
As of my knowledge, in the latest update there's no longer required any ```AUTH_KEY``` for installing. But the Docker file haven't updated with respect to the latest release. By address this issue, I've modified the all the three files in ```examples/docker```. Now can be build docker image without any Hassel. 

```Signed-off-by: Avinag Udayagiri <udayagiriavinag@gmail.com>```