### PR TITLE
[CI] Remove `modular auth` in CI as it's not needed anymore

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -48,9 +48,6 @@ jobs:
 
       - name: Install nightly Mojo compiler
         run: |
-          # The <auth_token> of "examples" is arbitrary but something
-          # needs to be provided.
-          modular auth examples
           modular install nightly/mojo
 
           # Put Mojo on the PATH


### PR DESCRIPTION
As the title says

EDIT: Weird, locally I don't need to do it anymore...