### PR TITLE
Revert "[tools] Simplify doc validation"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         stages: [commit]
       - id: check-docstrings
         name: check-docstrings
-        entry: mojo doc --validate-doc-strings stdlib/src
+        entry: python3 ./stdlib/scripts/check-docstrings.py
         language: system
         pass_filenames: false
         stages: [commit]


### PR DESCRIPTION
Reverts modularml/mojo#2795.  Despite being simpler, `--validate-doc-strings` along isn't sufficient.  In order the doc strings to be enforced properly, we'd need to also specify `--diagnose-missing-doc-strings`.  This is a bit silly in principle (superfluous rather).  Moreover, it's not user-friendly since that option dumps all the JSON to `stdout` even if there are no errors.  So, revert this commit entirely since the developer experience was superior with the wrapper Python script for checking `stderr`.  I've started a conversation internally about this as it's not great either way currently.