### PR TITLE
Proposed String and List Slicing Fix

### DIFF
--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -90,9 +90,12 @@ struct Slice(Stringable, EqualityComparable):
             end: The end value.
             step: The step value.
         """
-        self.start = _default_or(start, 0)
-        self.end = _default_or(end, _int_max_value())
         self.step = _default_or(step, 1)
+        if self.step < 0:
+            self.start = _default_or(start, _int_max_value())
+        else:
+            self.start = _default_or(start, 0)
+        self.end = _default_or(end, _int_max_value())
 
     fn __str__(self) -> String:
         """Gets the string representation of the span.
@@ -161,6 +164,10 @@ struct Slice(Stringable, EqualityComparable):
             The slice index.
         """
         return self.start + index(idx) * self.step
+
+    @always_inline("nodebug")
+    fn _has_start(self) -> Bool:
+        return self.start != _int_max_value()
 
     @always_inline("nodebug")
     fn _has_end(self) -> Bool:

--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -103,7 +103,10 @@ struct Slice(Stringable, EqualityComparable):
         Returns:
             The string representation of the span.
         """
-        var res = str(self.start)
+
+        var res = String()
+        if self._has_start():
+            res += str(self.start)
         res += ":"
         if self._has_end():
             res += str(self.end)
@@ -172,6 +175,31 @@ struct Slice(Stringable, EqualityComparable):
     @always_inline("nodebug")
     fn _has_end(self) -> Bool:
         return self.end != _int_max_value()
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn _adjust_span[T: Sized](object: T, span: Self) -> Self:
+        """Adjusts the provided slice based on the length of the object"""
+
+        var adjusted_span = span
+         
+        if adjusted_span.start < 0:
+            adjusted_span.start = len(object) + adjusted_span.start
+        if adjusted_span.end < 0:
+            adjusted_span.end = len(object) + adjusted_span.end
+
+        if adjusted_span.step < 0:
+            if not adjusted_span._has_start():
+                adjusted_span.start = len(object) - 1
+            if not adjusted_span._has_end():
+                adjusted_span.end = -1
+        else:
+            if not adjusted_span._has_start():
+                adjusted_span.start = 0
+            if not adjusted_span._has_end():
+                adjusted_span.end = len(object)
+        
+        return adjusted_span
 
 
 @always_inline("nodebug")

--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -179,10 +179,11 @@ struct _StridedRange(Sized, ReversibleRange, _StridedIterable):
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:
-        # FIXME(#38392)
-        # if (self.step > 0) == (self.start > self.end):
-        #     return 0
-        return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
+        if (self.step > 0 and self.start > self.end) or 
+            (self.step < 0 and self.start < self.end):
+            return 0
+        else:
+            return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
 
     @always_inline("nodebug")
     fn __getitem__(self, idx: Int) -> Int:

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -927,7 +927,7 @@ struct String(
             A new string containing the string at the specified positions.
         """
 
-        var adjusted_span = self._adjust_span(span)
+        var adjusted_span = Slice._adjust_span(self, span)
         var adjusted_span_len = adjusted_span.unsafe_indices()
         if adjusted_span.step == 1:
             return StringRef(self._buffer.data + span.start, adjusted_span_len)
@@ -1133,38 +1133,6 @@ struct String(
     # ===------------------------------------------------------------------=== #
     # Methods
     # ===------------------------------------------------------------------=== #
-
-    @always_inline
-    fn _adjust_span(self, span: Slice) -> Slice:
-        """Adjusts the span based on the string length."""
-        var adjusted_span = span
-         
-        print("Slice Check Before: ", adjusted_span.start, adjusted_span.end, adjusted_span.step) 
-
-        if adjusted_span.start < 0:
-            adjusted_span.start = len(self) + adjusted_span.start
-        if adjusted_span.end < 0:
-            adjusted_span.end = len(self) + adjusted_span.end
-
-        if adjusted_span.step < 0:
-            if not adjusted_span._has_start():
-                adjusted_span.start = len(self) - 1
-            if not adjusted_span._has_end():
-                adjusted_span.end = -1
-        else:
-            if not adjusted_span._has_start():
-                adjusted_span.start = 0
-            if not adjusted_span._has_end():
-                adjusted_span.end = len(self)
-
-        '''
-        if span.step < 0:
-            var tmp = adjusted_span.end
-            adjusted_span.end = adjusted_span.start - 1
-            adjusted_span.start = tmp - 1
-        '''
-        print("Slice Check After: ", adjusted_span.start, adjusted_span.end, adjusted_span.step) 
-        return adjusted_span
 
     fn format_to(self, inout writer: Formatter):
         """

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -1138,20 +1138,32 @@ struct String(
     fn _adjust_span(self, span: Slice) -> Slice:
         """Adjusts the span based on the string length."""
         var adjusted_span = span
+         
+        print("Slice Check Before: ", adjusted_span.start, adjusted_span.end, adjusted_span.step) 
 
         if adjusted_span.start < 0:
             adjusted_span.start = len(self) + adjusted_span.start
-
-        if not adjusted_span._has_end():
-            adjusted_span.end = len(self)
-        elif adjusted_span.end < 0:
+        if adjusted_span.end < 0:
             adjusted_span.end = len(self) + adjusted_span.end
 
+        if adjusted_span.step < 0:
+            if not adjusted_span._has_start():
+                adjusted_span.start = len(self) - 1
+            if not adjusted_span._has_end():
+                adjusted_span.end = -1
+        else:
+            if not adjusted_span._has_start():
+                adjusted_span.start = 0
+            if not adjusted_span._has_end():
+                adjusted_span.end = len(self)
+
+        '''
         if span.step < 0:
             var tmp = adjusted_span.end
             adjusted_span.end = adjusted_span.start - 1
             adjusted_span.start = tmp - 1
-
+        '''
+        print("Slice Check After: ", adjusted_span.start, adjusted_span.end, adjusted_span.step) 
         return adjusted_span
 
     fn format_to(self, inout writer: Formatter):

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -708,26 +708,6 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return ptr
 
     @always_inline
-    fn _adjust_span(self, span: Slice) -> Slice:
-        """Adjusts the span based on the list length."""
-        var adjusted_span = span
-
-        if adjusted_span.start < 0:
-            adjusted_span.start = len(self) + adjusted_span.start
-
-        if not adjusted_span._has_end():
-            adjusted_span.end = len(self)
-        elif adjusted_span.end < 0:
-            adjusted_span.end = len(self) + adjusted_span.end
-
-        if span.step < 0:
-            var tmp = adjusted_span.end
-            adjusted_span.end = adjusted_span.start - 1
-            adjusted_span.start = tmp - 1
-
-        return adjusted_span
-
-    @always_inline
     fn __getitem__(self, span: Slice) -> Self:
         """Gets the sequence of elements at the specified positions.
 
@@ -738,7 +718,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             A new list containing the list at the specified span.
         """
 
-        var adjusted_span = self._adjust_span(span)
+        var adjusted_span = Slice._adjust_span(self, span)
         var adjusted_span_len = adjusted_span.unsafe_indices()
 
         if not adjusted_span_len:

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -14,8 +14,6 @@
 
 from testing import assert_equal
 
-from testing import assert_equal
-
 
 def test_range_len():
     # Usual cases
@@ -32,11 +30,10 @@ def test_range_len():
     assert_equal(range(0, 0).__len__(), 0, "len(range(0, 0))")
     assert_equal(range(10, 0).__len__(), 0, "len(range(10, 0))")
     assert_equal(range(0, 0, 1).__len__(), 0, "len(range(0, 0, 1))")
-    # FIXME(#38392)
-    # assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
-    # assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
-    # assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
-    # assert_equal(range(10, 5, 10).__len__(), 0, "len(range(10, 5, 10))")
+    assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
+    assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
+    assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
+    assert_equal(range(10, 5, 10).__len__(), 0, "len(range(10, 5, 10))")
     assert_equal(range(5, 10, 20).__len__(), 1, "len(range(5, 10, 20))")
     assert_equal(range(10, 5, -20).__len__(), 1, "len(range(10, 5, -20))")
 

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -66,6 +66,9 @@ def test_has_end():
     alias is_end = Slice(None, None, None)._has_end()
     assert_false(is_end)
 
+def test_has_start():
+    alias has_start = Slice(None, None, -1)._has_start()
+    assert_false(has_start)
 
 struct SliceStringable:
     fn __init__(inout self):
@@ -80,6 +83,9 @@ def test_slice_stringable():
     assert_equal(s[2::-1], "2::-1")
     assert_equal(s[1:-1:2], "1:-1:2")
     assert_equal(s[:-1], "0:-1:1")
+    assert_equal(s[::1], "0::1") 
+    assert_equal(s[::], "0::1") 
+    assert_equal(s[::-1], "::-1")
 
 
 def test_indexing():
@@ -93,5 +99,6 @@ def main():
     test_none_end_folds()
     test_slicable()
     test_has_end()
+    test_has_start()
     test_slice_stringable()
     test_indexing()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -285,12 +285,10 @@ fn test_string_indexing() raises:
 
     assert_equal("!!ojoM olleH", str[::-1])
 
-    assert_equal("!!ojoM oll", str[2::-1])
-
+    assert_equal("leH", str[2::-1])
     assert_equal("!oo le", str[::-2])
-
-    assert_equal("!jMolH", str[:-1:-2])
-
+    assert_equal("", str[:-1:-2])
+    assert_equal("M o", str[6:3:-1])
 
 fn test_atol() raises:
     # base 10
@@ -1083,6 +1081,8 @@ def test_indexing():
 
 
 def main():
+    """Testing my changes."""
+    '''
     test_constructors()
     test_copy()
     test_equality_operators()
@@ -1096,7 +1096,9 @@ def main():
     test_stringref_strip()
     test_ord()
     test_chr()
+    '''
     test_string_indexing()
+    '''
     test_atol()
     test_atol_base_0()
     test_atof()
@@ -1126,3 +1128,4 @@ def main():
     test_intable()
     test_string_mul()
     test_indexing()
+    '''

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -1081,8 +1081,6 @@ def test_indexing():
 
 
 def main():
-    """Testing my changes."""
-    '''
     test_constructors()
     test_copy()
     test_equality_operators()
@@ -1096,9 +1094,7 @@ def main():
     test_stringref_strip()
     test_ord()
     test_chr()
-    '''
     test_string_indexing()
-    '''
     test_atol()
     test_atol_base_0()
     test_atof()
@@ -1128,4 +1124,3 @@ def main():
     test_intable()
     test_string_mul()
     test_indexing()
-    '''

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -48,6 +48,16 @@ def test_list():
     assert_equal(3, list[-2])
     assert_equal(4, list[-1])
 
+    var slice = list[::-1]
+    for i in range(len(slice)):
+        assert_equal(slice[i], list[len(list)-(i+1)])
+
+    slice = list[:2:-1]
+    test = List(4, 3)
+
+    for i in range(len(slice)):
+        assert_equal(slice[i], test[i])
+
     list[2] = -2
     assert_equal(-2, list[2])
 


### PR DESCRIPTION
# Mojo Pull Request Write-up

## Synoptic Changelog

In `stdlib`:

1. src/builtin/range.mojo
    - Adjusted `_StridedRange.__len__` definition to return 0 as needed.

2. src/builtin/string.mojo
    - Fix `String._adjust_span`: Remove negative step logic as it doesn't appear to work properly.
    - Changed to call Slice._adjust_span
    - Removed `String._adjust_span` method.
    
3. src/builtin/builtin_slice.mojo
    - Changed `__init__` method to account for `NoneType` `Slice.start` value.
    - Added `Slice._adjust_span` method to replace those in `String` and `List`
    - Added a `Slice._has_start` method to match `Slice._has_end`
    - Adjusted `__str__` to account for slices of form `a[::step]`.
    
4. test/builtin/test_string.mojo
    - Changed `test_string_indexing` to add additional test cases; changed current test cases to reflect Python behavior.

5. test/builtin/test_range.mojo
    - Re-enabled edge case indexing tests.

6. test/builtin/test_slice.mojo
    - Added `test_has_start`
    - Added more cases in `test_slice_stringable`

7. test/collections/test_list.mojo
    - Added tests for list slicing that matches Python behavior

## Introduction

I am submitting this pull request in attempt to fix what I think is a bug in the slicing behavior of both strings and lists. I may be incorrect, but comparing the results of slicing operations between Python and Mojo reveals a divergence. My assumption in undertaking this pull request is that Mojo's Python emulation must be one-to-one.

## Background

While studying the source code, I came across the `String._adjust_span` method:

```mojo
@always_inline
fn _adjust_span(self, span: Slice) -> Slice:
    """Adjusts the span based on the string length."""
    var adjusted_span = span

    if adjusted_span.start < 0:
        adjusted_span.start = len(self) + adjusted_span.start

    if not adjusted_span._has_end():
        adjusted_span.end = len(self)
    elif adjusted_span.end < 0:
        adjusted_span.end = len(self) + adjusted_span.end

    if span.step < 0:
        var tmp = adjusted_span.end
        adjusted_span.end = adjusted_span.start - 1
        adjusted_span.start = tmp - 1

    return adjusted_span
```

From my understanding, the purpose of this method is to calculate the proper indicies for the `String.__getitem__` method. The end and start adjustments in the 'step' conditional caught my eye and led to experimentation in both Python and Mojo to compare the behaviors of the two:

Python:

```python

>> s = "Hello Mojo!!"
>> s[:3:-1]
'!!ojoM o'
>> # Example 2
>> s[0:3:-1]
''
```

```mojo
    1> var s: String = "Hello Mojo!!"
    2. print(s[:3:-1])
leH
    3> # Example 2
    4. print(s[0:3:-1])
leH
```

There are more examples, but I think this is sufficient to show divergence in results.

## Investigating the Divergence

The divergence in behavior is the result of two reasons from what I could see. First, the calculation of indices does not match the behavior of Python for negative steps and `None` values for 'start' and/or 'end'. The second reason is that `_StridedRange` does not give the correct length value when compared to Python's behavior for `range` objects. 

### How it works currently

`String._adjust_span` does a decrement and swap of both 'start' and 'end' every
time 'step' is negative. So, for a slice such as `s[3:0:-1]`, for example, the
resulting slice object would be described `Slice(-1, 2, -1)`. In the `Slice.__getitem__` function, this slice has its length taken to determine the number of iterations in the `for` loop using `Slice.unsafe_indices` (nightly). This method is defined as:

```mojo
@always_inline
fn unsafe_indices(self) -> Int:
    """Return the length of the slice.

    Only use this function if start/end is guaranteed to be not None.

    Returns:
        The length of the slice.
    """

    return len(range(self.start, self.end, self.step))
```

It calls on the length function for the underlying object produced by `range`. Given the call signature, this object is of type `_StridedRange`, whose `__len__` function is defined as:

```mojo
# FIXME comment removed for readability
@always_inline("nodebug")
    fn __len__(self) -> Int:
        return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
```

Calling this function on the example slice `Slice(-1, 2, -1)` generated from `String._adjust_span` results in a lenght of 3 when in Python, the length would be 0. This slice is then used for iterating over the String:

```mojo
...
var buffer = Self._buffer_type()
buffer.resize(adjusted_span_len + 1, 0)
var ptr = self.unsafe_uint8_ptr()
for i in range(adjusted_span_len):
    buffer[i] = ptr[adjusted_span[i]]
    # i=0: buffer[0] = ptr[(-1 + 0*-1)] = ptr[-1]
    # i=1: buffer[1] = ptr[(-1 + 1*-1)] = ptr[-2]
    # i=2: buffer[2] = ptr[(-1 + 2*-1)] = ptr[-3]
...
```

We can see that the created pointer is indexed using the retrieved index from the Slice object. So, given the length of the Slice object is 3 in the current implementation, the resulting buffer is filled with data. However, due to the indices, the pointer is referenced using negative indices. Since the pointer is an `UnsafePointer[Uint8]`, I think this would read the wrong data, but I'm not too sure on that part.

In any case, I don't think this is the desired behavior.

## Fixes

First, I fixed the length calculation of `_StridedRange` to account for the cases where zero should be returned. Given some slice object, span, these conditions are:

- span.step < 0 and span.start < span.end
- span.step > 0 and span.start > span.end

Otherwise, the length is calculated using the div ceil method as before.

Next was fixing the index calculations in `String._adjust_span`. To do so, I introduced additional logic in the relevant `Slice.__init__`. Essentially, similar logic that is used when `Slice(start: T0, end: T1=NoneType, step: T2)` is applied when `T0` is `NoneType`. `Slice._has_start` was added to match `Slice._has_end`, and `Slice.__str__` was adjusted accordingly.

Since `List` also has an `_adjust_span` method that identical to `String._adjust_span`, I added a new `Slice._adjust_span[T: Sized](object: T, span: Self) -> Self` static method. Both `List` and `String` had their respective `_adjust_span` method removed and now their `__getitem__` methods use `Slice._adjust_span`. This way, changes in that method are applied to both types. Also, it seemed right to have `Slice` produce additional `Slice` objects rather than `List` and `String`.

Tests were also modified to expect Python-like behavior. Currently all modified tests pass.

## Conclusion

In this pull request, I aim to rectify a perceived discrepancy between slicing behaviors of Mojo `String`. In the process, I adjusted the length calculation of `_StridedRange`, made multiple modifications to `Slice`, and adjusted `List`. Relevant tests were changed and added to, and all relevant tests pass. I hope the above report explains my thought process cogently.