### PR TITLE
[docs] Fix typo in `changelog-released.md`

### DIFF
--- a/docs/changelog-released.md
+++ b/docs/changelog-released.md
@@ -35,7 +35,7 @@ modular update mojo
   [PR #2609](https://github.com/modularml/mojo/pull/2609) by
   [@mzaks](https://github.com/mzaks)
 
-- Mojo functions can return an auto-dereferenced refeference to storage with a
+- Mojo functions can return an auto-dereferenced reference to storage with a
   new `ref` keyword in the result type specifier.  For example:
 
   ```mojo


### PR DESCRIPTION
Change "refeference" to "reference"