### PR TITLE
[stdlib] Add `map` builtin

### DIFF
--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -309,3 +309,27 @@ fn range[
         The constructed range.
     """
     return _StridedRange(int(start), int(end), int(step))
+
+
+fn map[
+    ElementType: CollectionElement,
+    ResultElementType: CollectionElement, //,
+    func: fn (ElementType) -> ResultElementType,
+](input_list: List[ElementType], /) -> List[ResultElementType]:
+    """Maps a function over a list.
+
+    Parameters:
+        ElementType: The type of the input list elements.
+        ResultElementType: The type of the output list elements.
+        func: The function to apply to each element.
+
+    Args:
+        input_list: The list to map over.
+
+    Returns:
+        A new list with the function applied to each element.
+    """
+    var result = List[ResultElementType](capacity=len(input_list))
+    for elem in input_list:
+        result.append(func(elem[]))
+    return result

--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -311,6 +311,8 @@ fn range[
     return _StridedRange(int(start), int(end), int(step))
 
 
+# TODO: Use iterators instead of List when it's possible to
+# represent them using traits.
 fn map[
     ElementType: CollectionElement,
     ResultElementType: CollectionElement, //,

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -122,8 +122,30 @@ def test_indexing():
     assert_equal(r[3], 3)
 
 
+def test_map_to_str():
+    var input_list = List[Int](0, 1, 2, 3)
+    var output_list = map[str[Int]](input_list)
+    var expected = List[String]("0", "1", "2", "3")
+    for i in range(len(expected)):
+        assert_equal(output_list[i], expected[i])
+
+
+fn remove_0_suffix(s: String) -> String:
+    return s.removesuffix("_0")
+
+
+def test_map_remove_suffix():
+    var input_list = List[String]("a_0", "b_0", "c_0", "d_0")
+    var output_list = map[remove_0_suffix](input_list)
+    var expected = List[String]("a", "b", "c", "d")
+    for i in range(len(expected)):
+        assert_equal(output_list[i], expected[i])
+
+
 def main():
     test_range_len()
     test_range_getitem()
     test_range_reversed()
     test_indexing()
+    test_map_to_str()
+    test_map_remove_suffix()

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -124,10 +124,12 @@ def test_indexing():
 
 def test_map_to_str():
     var input_list = List[Int](0, 1, 2, 3)
-    var output_list = map[str[Int]](input_list)
     var expected = List[String]("0", "1", "2", "3")
-    for i in range(len(expected)):
-        assert_equal(output_list[i], expected[i])
+    for output_element in map[str[Int]](input_list):
+        assert_equal(output_element, expected.pop(0))
+
+    # Ensure the iterator had the right number of elements
+    assert_equal(len(expected), 0)
 
 
 fn remove_0_suffix(s: String) -> String:
@@ -136,10 +138,12 @@ fn remove_0_suffix(s: String) -> String:
 
 def test_map_remove_suffix():
     var input_list = List[String]("a_0", "b_0", "c_0", "d_0")
-    var output_list = map[remove_0_suffix](input_list)
     var expected = List[String]("a", "b", "c", "d")
-    for i in range(len(expected)):
-        assert_equal(output_list[i], expected[i])
+    for output_element in map[remove_0_suffix](input_list):
+        assert_equal(output_element, expected.pop(0))
+
+    # Ensure the iterator had the right number of elements
+    assert_equal(len(expected), 0)
 
 
 def main():


### PR DESCRIPTION
This function is here to help write algorithms. It's present in python under this form: https://docs.python.org/3/library/functions.html#map

Currently Mojo does not support list comprehensions. Despite this, we would still like to be able to write simple code when mapping a function over an iterator. 

Since making a trait for iterators is hard/impossible right now, we'll use List in the meantime. That will allow us to write code that won't change when we switch `List` for iterators later on.

This will notably be useful when writing `__str__` and `__repr__` for collections.