### PR TITLE
[CI] Do not cancel other CI jobs when one of them failed

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   test-examples:
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
 


### PR DESCRIPTION
When trying to debug strange CI errors, it's helpful to know if the error happened in one OS or in all OSs. But currenty as soon as one of the build fails, the other are canceled. Let's always run all jobs until the end.

Motivating example: https://github.com/modularml/mojo/pull/2945 which I can't reproduce locally.