### PR TITLE
[docs] fix typo for 24.2 in changelog-released.md

### DIFF
--- a/docs/changelog-released.md
+++ b/docs/changelog-released.md
@@ -51,7 +51,7 @@ Big themes for this release:
 ### Language changes
 
 - Mojo has changed how `def` function arguments are processed.  Previously, by
-  default, arguments to a `def` were treated treated according to the `owned`
+  default, arguments to a `def` were treated according to the `owned`
   convention, which makes a copy of the value, enabling that value to be mutable
   in the callee.
 


### PR DESCRIPTION
Opening a new PR on top of nightly instead of main, previous PR: https://github.com/modularml/mojo/pull/2980