### PR TITLE
[tools] Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Modular installer
         run: |


### PR DESCRIPTION
Resolves deprecation warning on runs e.g. https://github.com/modularml/mojo/actions/runs/9425680009

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2.
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.

Reference https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4

(Rebase of https://github.com/modularml/mojo/pull/2987)