### PR TITLE
[docs] Explicitly provide Int parameter when calling repeat in docs example

### DIFF
--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -158,7 +158,7 @@
     "    for i in range(count):\n",
     "        print(msg)\n",
     "\n",
-    "repeat[3](3)"
+    "repeat[Int, 3](3)"
    ]
   },
   {

--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -139,16 +139,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3\n",
-      "3\n",
-      "3\n"
+      "42\n",
+      "42\n"
      ]
     }
    ],
@@ -158,7 +157,8 @@
     "    for i in range(count):\n",
     "        print(msg)\n",
     "\n",
-    "repeat[Int, 3](3)"
+    "# Must use keyword parameter for `count`\n",
+    "repeat[count=2](42)"
    ]
   },
   {
@@ -167,6 +167,40 @@
    "source": [
     "This updated function takes any `Stringable` type, so you can pass it an `Int`,\n",
     "`String`, or `Bool` value.\n",
+    "\n",
+    "You can't pass the `count` as a positional keyword without also specifying `MsgType`.\n",
+    "You can put `//` after `MsgType` to specify that it's always inferred by the argument. Now\n",
+    "you can pass the following parameter `count` positionally:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n",
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "fn repeat[MsgType: Stringable, //, count: Int](msg: MsgType):\n",
+    "    @parameter\n",
+    "    for i in range(count):\n",
+    "        print(msg)\n",
+    "\n",
+    "# MsgType is always inferred, so first positional keyword `2` is passed to `count`\n",
+    "repeat[2](42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
     "Mojo's support for generics is still early. You can write generic functions like\n",
     "this using traits and parameters. You can also write generic collections like\n",
@@ -189,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -341,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -485,7 +519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -535,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -575,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -709,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -851,7 +885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -895,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -920,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,7 +995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1006,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1068,7 +1102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1117,7 +1151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1177,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1213,12 +1247,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
-    "alias Bytes = SIMD[DType.uint8, _]\n",
-    "var b = Bytes[8]()"
+    "alias StringKeyDict = Dict[String, _]\n",
+    "var b = StringKeyDict[UInt8]()\n",
+    "b[\"answer\"] = 42"
    ]
   },
   {
@@ -1234,7 +1269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1331,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1367,7 +1402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1398,7 +1433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1415,7 +1450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1436,7 +1471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1483,7 +1518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1491,7 +1526,7 @@
     "struct Fudge[sugar: Int, cream: Int, chocolate: Int = 7](Stringable):\n",
     "    fn __str__(self) -> String:\n",
     "        var values = StaticIntTuple[3](sugar, cream, chocolate)\n",
-    "        return str(\"Fudge\") + values"
+    "        return str(\"Fudge\") + str(values)"
    ]
   },
   {
@@ -1504,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1526,7 +1561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1544,7 +1579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1584,7 +1619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1604,12 +1639,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
     "fn devour[su: Int, ch: Int](f: Fudge[su, 6, ch]):\n",
-    "        print(str(\"Devoured \") + str(f))"
+    "    print(str(\"Devoured \") + str(f))"
    ]
   },
   {
@@ -1625,7 +1660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1642,7 +1677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1671,7 +1706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1705,9 +1740,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Mojo",
+   "display_name": "Mojo Source",
    "language": "mojo",
-   "name": "mojo-jupyter-kernel"
+   "name": "mojo-source-kernel"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
I encountered a compile error while going through the examples to learn Mojo.

```mojo
fn repeat[MsgType: Stringable, count: Int](msg: MsgType):
    @parameter
    for i in range(count):
        print(msg)

repeat[3](3)
```

It looks like the compiler currently can't infer the parameter correctly otherwise and tries to use the `3` for `MsgType`: `cannot pass 'IntLiteral' value, expected 'Stringable' in call parameter`

Adding the parameter explictly makes the example compile again:
```mojo
repeat[Int, 3](3)
```

Note that it works fine if we change `MsgType` to be an infer-only parameter, so that could be an alternative. But infer-only parameters are only introduced a bit below in the docs.

```mojo
fn repeat[MsgType: Stringable, //, count: Int](msg: MsgType):
    @parameter
    for i in range(count):
        print(msg)

repeat[3](3)
```