### PR TITLE
Why mojo link fix

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -24,7 +24,7 @@ feedback](/mojo/community).
 
 - **Get started**
 
-  - [Why Mojo](/mojo/manual/why-mojo)
+  - [Why Mojo](/mojo/why-mojo)
   - [Get started with Mojo](/mojo/manual/get-started)
 
 - **Language basics**


### PR DESCRIPTION
Currently `Why mojo` link is redirecting to https://docs.modular.com/mojo/manual/why-mojo, but it should instead point to


https://docs.modular.com/mojo/why-mojo