### PR TITLE
[docs] Update "Contributing" section in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -88,3 +88,13 @@ podman run \
 The Mojo examples and notebooks in this repository are licensed  
 under the Apache License v2.0 with LLVM Exceptions  
 (see the LLVM [License](https://llvm.org/LICENSE.txt)).
+
+## Contributing
+
+As a contributor, your efforts and expertise are invaluable in driving the
+evolution of the Mojo programming language. The [Mojo contributor
+guide](../CONTRIBUTING.md) provides all the information necessary to make
+meaningful contributions—from understanding the submission process to
+adhering to best practices:
+
+- [Mojo contributor guide](../CONTRIBUTING.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,9 +88,3 @@ podman run \
 The Mojo examples and notebooks in this repository are licensed  
 under the Apache License v2.0 with LLVM Exceptions  
 (see the LLVM [License](https://llvm.org/LICENSE.txt)).
-
-## Contributing
-
-Thanks for your interest in contributing to this repository!  
-We are not accepting pull requests at this time, but are actively  
-working on a process to accept contributions. Please stay tuned.


### PR DESCRIPTION
Proposing updating this section as it conflicts with the contents under https://github.com/modularml/mojo/tree/nightly?tab=readme-ov-file#contributing, inspired by contents in https://github.com/modularml/mojo/blob/nightly/stdlib/README.md#contributing-to-the-mojo-standard-library.