### PR TITLE
[CI] Split unit tests and pre-commit tests in the CI

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -77,19 +77,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-${{env.LLVM_VERSION}} 100
           sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-${{env.LLVM_VERSION}} 100
 
-
           python3 -m pip install lit
-      
-      - name: Install pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit install
-      
-      - name: Run pre-commit
-        # If this step ever gets too slow, we can move the 
-        # pre-commit run to a separate job so that it runs at the
-        # same time as the unit tests.
-        run: pre-commit run --all-files
 
       - name: Install build tools (macOS)
         if: ${{ matrix.os == 'macos-14' }}

--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -1,0 +1,61 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+name: Run pre-commit
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test-examples:
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download Modular installer
+        run: |
+          curl -s https://get.modular.com | sh -
+
+      - name: Install nightly Mojo compiler
+        run: |
+          # The <auth_token> of "examples" is arbitrary but something
+          # needs to be provided.
+          modular auth examples
+          modular install nightly/mojo
+
+          # Put Mojo on the PATH
+          echo "MODULAR_HOME=$HOME/.modular" >> $GITHUB_ENV
+          echo "$HOME/.modular/pkg/packages.modular.com_nightly_mojo/bin" >> $GITHUB_PATH
+      
+      - name: Install pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit install
+      
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+

--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -22,7 +22,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  test-examples:
+  lint:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
 


### PR DESCRIPTION
We get two benefits from this:
1) We save ~30s on the unit test run
2) We have a better error reporting when something fail, we can quickly see that the linters were not run.