### PR TITLE
[docs] Correct "Python integration" hyperlink in manual

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -60,7 +60,7 @@ feedback](/mojo/community).
 
 - **Python**
 
-  - [Python integration](/mojo/manual/python)
+  - [Python integration](/mojo/manual/python/)
   - [Python types](/mojo/manual/python/types)
 
 - **Tools**

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -60,7 +60,7 @@ feedback](/mojo/community).
 
 - **Python**
 
-  - [Python integration](/mojo/manual/python/index)
+  - [Python integration](/mojo/manual/python)
   - [Python types](/mojo/manual/python/types)
 
 - **Tools**


### PR DESCRIPTION
Seem to be getting a 308 response code from the `/index` path hyperlinked here - https://docs.modular.com/mojo/manual/python/index - which inconsistently redirects me to https://docs.modular.com/mojo/manual/python, but sometimes does not and results in this Page Not Found error, is anyone else able to reproduce this?

![image](https://github.com/modularml/mojo/assets/416477/7fb01e57-e907-41b3-a04f-7b83195bd6ac)

Proposing changing the hyperlink to the redirected page directly.