### PR TITLE
parallelize over rows, cols - not rows,rows

### DIFF
--- a/examples/mandelbrot.mojo
+++ b/examples/mandelbrot.mojo
@@ -93,7 +93,7 @@ fn main() raises:
 
     @parameter
     fn bench_parallel():
-        parallelize[worker](rows, rows)
+        parallelize[worker](rows, cols)
 
     print("Number of physical cores:", num_physical_cores())
 


### PR DESCRIPTION
Parallelize over rows, cols - not rows,rows. Rows & cols happen to be the same value in this example.