### PR TITLE
[docs] Fix typos in pointers.ipynb

### DIFF
--- a/docs/manual/pointers.ipynb
+++ b/docs/manual/pointers.ipynb
@@ -646,7 +646,7 @@
     "and \n",
     "[`simd_strided_store()`](/mojo/stdlib/memory/unsafe/DTypePointer#simd_strided_store)\n",
     "methods to invert the red pixel values in an image, 8 values at a time. (Note\n",
-    "that this function only handles images with where the number of pixels is evenly\n",
+    "that this function only handles images where the number of pixels is evenly\n",
     "divisible by eight.)"
    ]
   },

--- a/docs/manual/pointers.ipynb
+++ b/docs/manual/pointers.ipynb
@@ -437,7 +437,7 @@
     "\n",
     "As mentioned in [Allocating memory](#allocating-memory), you can use an \n",
     "`UnsafePointer` to allocate memory for multiple values. The memory is allocated\n",
-    "in as single, contiguous block. Pointers support arithmetic: adding an integer\n",
+    "as a single, contiguous block. Pointers support arithmetic: adding an integer\n",
     "to a pointer returns a new pointer offset by the specified number of values from\n",
     "the original pointer:\n",
     "\n",

--- a/docs/manual/pointers.ipynb
+++ b/docs/manual/pointers.ipynb
@@ -575,7 +575,7 @@
    "source": [
     "## `DTypePointer`: handling numeric data\n",
     "\n",
-    "The [`DTypePointer`](/mojo/stdlib/memory/unsafe/DTypePointer) is an unsafe\n",
+    "A [`DTypePointer`](/mojo/stdlib/memory/unsafe/DTypePointer) is an unsafe\n",
     "pointer that supports some additional methods for loading and storing numeric\n",
     "data. Like the [`SIMD`](/mojo/stdlib/builtin/simd/SIMD) type, it's parameterized\n",
     "on [`DType`](/mojo/stdlib/builtin/dtype/DType) as described in \n",


### PR DESCRIPTION
- Change "in as" to "as a"
- Change "The DTypePointer" to "A DTypePointer"
- Change "with where" to "where"