### PR TITLE
[examples] Improve `examples/matmul.mojo` by 2-3x via split-K sub-tiling

### DIFF
--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -203,7 +203,7 @@ fn matmul_unrolled[mode: Int](inout C: Matrix, A: Matrix, B: Matrix):
     parallelize[calc_row](C.rows, num_workers)
 
 
-# Perform 2D tiling on the iteration space defined by end_x and end_y, parallelizing over y.
+# Perform 2D tiling on the iteration space defined by end_m and end_n, parallelizing over m.
 fn tile_parallel[
     tiled_fn: Tile2DFunc, tile_m: Int, tile_n: Int
 ](end_m: Int, end_n: Int,):

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -373,4 +373,5 @@ def main():
         bench[matmul_unrolled[3], "Unrolled - Performance Cores:"](
             python_gflops, numpy_gflops
         )
-        bench[matmul_reordered, "Reordered:"](python_gflops, numpy_gflops)
+    # CHECK: Optimized Implementation
+    bench[matmul_reordered, "Reordered:"](python_gflops, numpy_gflops)

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -94,7 +94,7 @@ def run_matmul_numpy() -> Float64:
     var py = Python.import_module("builtins")
 
     var gflops = pymatmul.benchmark_matmul_numpy(M, N, K).to_float64()
-    py.print(py.str("{:<13}{:>8.3f} GFLOPS").format("Numpy:", gflops))
+    py.print(py.str("{:<18}{:>8.3f} GFLOPS").format("Numpy:", gflops))
 
     return gflops
 

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -304,7 +304,7 @@ fn bench[
 
     var py = Python.import_module("builtins")
     _ = py.print(
-        py.str("{:<13}{:>8.3f} GFLOPS {:>9.2f}x Python {:>9.2f}x Numpy").format(
+        py.str("{:<18}{:>8.3f} GFLOPS {:>9.2f}x Python   {:.2f}x Numpy").format(
             name, gflops, speedup, numpy_speedup
         )
     )

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -34,12 +34,14 @@ alias type = DType.float32
 # 2x or 4x helps with pipelining and running multiple SIMD operations in parallel.
 alias nelts = get_simd_width()
 
+
 fn get_simd_width() -> Int:
     @parameter
     if info.is_apple_silicon():
         return 4 * simdwidthof[type]()
     else:
         return 2 * simdwidthof[type]()
+
 
 alias tile_n = 64  # N must be a multiple of this
 alias tile_k = 4  # K must be a multiple of this
@@ -230,9 +232,8 @@ fn tile_parallel[
 # Also partially unroll the loop over the reduction dimension (K)
 # and reorder the reduction inner loop with the row iteration inner loop
 fn matmul_reordered(inout C: Matrix, A: Matrix, B: Matrix):
-    alias nelts = simdwidthof[type]() * 8
     alias tile_m = 32
-    alias tile_n = nelts
+    alias tile_n = 32
     alias tile_k = max(4, K // 256)
 
     constrained[M % tile_m == 0, "M must be a multiple of tile_m"]()

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -63,10 +63,10 @@ struct Matrix[rows: Int, cols: Int]:
         self.store[1](y, x, val)
 
     fn load[nelts: Int](self, y: Int, x: Int) -> SIMD[type, nelts]:
-        return self.data.load[width=nelts](y * self.cols + x)
+        return SIMD[size=nelts].load(self.data, y * self.cols + x)
 
     fn store[nelts: Int](self, y: Int, x: Int, val: SIMD[type, nelts]):
-        return self.data.store[width=nelts](y * self.cols + x, val)
+        SIMD[size=nelts].store(self.data, y * self.cols + x, val)
 
 
 def run_matmul_python() -> Float64:

--- a/examples/matmul.mojo
+++ b/examples/matmul.mojo
@@ -282,7 +282,7 @@ fn matmul_reordered(inout C: Matrix, A: Matrix, B: Matrix):
 @always_inline
 fn bench[
     func: fn (inout Matrix, Matrix, Matrix) -> None, name: StringLiteral
-](base_gflops: Float64, numpy_gflops: Float64) raises:
+](base_gflops: Float64, np_gflops: Float64) raises:
     var A = Matrix[M, K].rand()
     var B = Matrix[K, N].rand()
     var C = Matrix[M, N]()
@@ -300,7 +300,7 @@ fn bench[
 
     var gflops = ((2 * M * N * K) / secs) / 1e9
     var speedup: Float64 = gflops / base_gflops
-    var numpy_speedup: Float64 = gflops / numpy_gflops
+    var numpy_speedup: Float64 = gflops / np_gflops
 
     var py = Python.import_module("builtins")
     _ = py.print(
@@ -363,24 +363,18 @@ def main():
 
     test_all()
     print("CPU Results\n")
-    var python_gflops = run_matmul_python()
-    var numpy_gflops = run_matmul_numpy()
+    var py_gflops = run_matmul_python()
+    var np_gflops = run_matmul_numpy()
 
     # Don't run all these benchmarks in CI, too resource intensive
     if not getenv("CI"):
-        bench[matmul_naive, "Naive:"](python_gflops, numpy_gflops)
-        bench[matmul_vectorized, "Vectorized:"](python_gflops, numpy_gflops)
-        bench[matmul_parallelized, "Parallelized:"](python_gflops, numpy_gflops)
-        bench[matmul_tiled, "Tiled:"](python_gflops, numpy_gflops)
-        bench[matmul_unrolled[0], "Unrolled:"](python_gflops, numpy_gflops)
-        bench[matmul_unrolled[1], "Unrolled - Physical Cores:"](
-            python_gflops, numpy_gflops
-        )
-        bench[matmul_unrolled[2], "Unrolled - Logical Cores:"](
-            python_gflops, numpy_gflops
-        )
-        bench[matmul_unrolled[3], "Unrolled - Performance Cores:"](
-            python_gflops, numpy_gflops
-        )
-    # CHECK: Optimized Implementation
-    bench[matmul_reordered, "Reordered:"](python_gflops, numpy_gflops)
+        bench[matmul_naive, "Naive:"](py_gflops, np_gflops)
+        bench[matmul_vectorized, "Vectorized:"](py_gflops, np_gflops)
+        bench[matmul_parallelized, "Parallelized:"](py_gflops, np_gflops)
+        bench[matmul_tiled, "Tiled:"](py_gflops, np_gflops)
+        bench[matmul_unrolled[0], "Unrolled:"](py_gflops, np_gflops)
+        bench[matmul_unrolled[1], "Physical Cores:"](py_gflops, np_gflops)
+        bench[matmul_unrolled[2], "Logical Cores:"](py_gflops, np_gflops)
+        bench[matmul_unrolled[3], "Performance Cores:"](py_gflops, np_gflops)
+    # CHECK: Reordered
+    bench[matmul_reordered, "Reordered:"](py_gflops, np_gflops)


### PR DESCRIPTION
This approach was already shown to work in my prior contribution https://github.com/modularml/mojo/pull/1280,

This PR adds back this optimization and partially fixes https://github.com/modularml/mojo/issues/2660
But seems to fall short of the peak FLOPs, which seems to be insanely high on M3 Max.
I did not implement swizzling L3 due to the CPU-cache size specific tuning required.

---

### Benchmark Results (Apple Silicon M3 Max):

Against baseline:
![image](https://github.com/user-attachments/assets/b6ca18e9-2eaa-4b50-8602-1de4855e92a6)



Against numpy:
<details>

![image](https://github.com/user-attachments/assets/c8236d81-a4cc-444b-a237-1b89b5e16074)

</details>


---



I do not have access to x86 machine, but it also ought to help (due to less cache thrashing)

My implementation still falls short and caps out at ~700 GFLOPs and 1/2 the perf of numpy. I attribute this to lack of cache swizzling / multi-level cache tiling and perf tuning.