### PR TITLE
[stdlib] Add `FileHandle` iterator and UTF-8 safeguards

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -116,10 +116,10 @@ struct _FileHandleIter[
                     capacity=self.length // 2,
                 )).as_string_slice()
             elif self.encoding == "UTF-32":
-                s = String.from_unicode(List[Int](
-                    unsafe_pointer=self.ptr.bitcast[DType.index](), 
-                    size=self.length // 2, 
-                    capacity=self.length // 2,
+                s = String.from_unicode(List[UInt32](
+                    unsafe_pointer=self.ptr.bitcast[DType.uint32](), 
+                    size=self.length // 4, 
+                    capacity=self.length // 4,
                 )).as_string_slice()
             var res = _is_newline_start(s.unsafe_ptr(), read_ahead):
             if res[0]:

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -35,7 +35,7 @@ from os import PathLike
 from sys import external_call
 
 from memory import AddressSpace, UnsafePointer
-from utils.string_slice import _is_newline_start
+from utils.string_slice import _is_newline_start, _is_valid_utf8
 
 
 @register_passable
@@ -285,6 +285,9 @@ struct FileHandle:
 
         if err_msg:
             raise err_msg^.consume_as_error()
+        
+        if not _is_valid_utf8(buf, int(size_copy)):
+            raise Error("UnicodeDecodeError: Invalid UTF-8 sequence found")
 
         return String(buf, int(size_copy) + 1)
 

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -562,8 +562,7 @@ struct FileHandle:
         return Int(i64_res.value)
 
     fn __len__(self) -> Int:
-        # TODO: need to fetch file byte size
-        return 0
+        return 0 # TODO: need to fetch file byte size
 
     fn __iter__(ref [_]self) -> _FileHandleIter[__lifetime_of(self)]:
         """Iterate over elements of the string slice, returning immutable references.
@@ -597,4 +596,6 @@ fn open[
     Returns:
       A file handle.
     """
+    if encoding.upper() not in ("ASCII", "UTF-8", "UTF-16", "UTF-32"):
+        raise Error("Encoding not supported: " + encoding)
     return FileHandle(path.__fspath__(), mode, encoding.upper())

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -515,6 +515,15 @@ struct FileHandle:
         """
         self._write(data.unsafe_ptr(), len(data))
 
+    fn write(self, data: UnsafePointer[UInt8], length: Int) raises:
+        """Write a borrowed sequence of data to the file.
+
+        Args:
+          data: The data to write to the file.
+          length: The amount of data to write to the file.
+        """
+        self._write(data, length)
+
     fn write(self, data: StringRef) raises:
         """Write the data to the file.
 


### PR DESCRIPTION
#### Proposed implementation:

Add FileHandle Iterator that decodes the file content. Add UTF-8 safeguards.

- `# TODO: need memory mapping`
- `# TODO: need to fetch file byte size`
- blocked until PR #3223 is merged
- blocked until PR #3239 is merged


@JoeLoser @laszlokindrat @ConnorGray do you guys agree with this direction ?