### PR TITLE
[docs] Add `str()` in `print_many()` in Functions

### DIFF
--- a/docs/manual/functions.ipynb
+++ b/docs/manual/functions.ipynb
@@ -552,7 +552,7 @@
     "    @parameter\n",
     "    fn print_elt[T: Stringable](a: T):\n",
     "        print_string(\" \")\n",
-    "        print_string(a)\n",
+    "        print_string(str(a))\n",
     "    rest.each[print_elt]()\n",
     "print_many(\"Bob\")"
    ]


### PR DESCRIPTION
Resolves `error: invalid call to 'print_string': argument #0 cannot be converted from 'T' to 'String' `