### PR TITLE
[stdlib] Fix utf32 indexing instead of utf8

### DIFF
--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -315,31 +315,30 @@ def test_chr():
 
 
 def test_string_indexing():
-    pass
-    # var str = String("Hello Mojo!!")
+    var str = String("Hello Mojo!!")
 
-    # assert_equal("H", str[0])
-    # assert_equal("!", str[-1])
-    # assert_equal("H", str[-len(str)])
-    # assert_equal("llo Mojo!!", str[2:])
-    # assert_equal("lo Mojo!", str[3:-1:1])
-    # assert_equal("lo Moj", str[3:-3])
+    assert_equal("H", str[0])
+    assert_equal("!", str[-1])
+    assert_equal("H", str[-len(str)])
+    assert_equal("llo Mojo!!", str[2:])
+    assert_equal("lo Mojo!", str[3:-1:1])
+    assert_equal("lo Moj", str[3:-3])
 
-    # assert_equal("!!ojoM olleH", str[::-1])
+    assert_equal("!!ojoM olleH", str[::-1])
 
-    # assert_equal("leH", str[2::-1])
+    assert_equal("leH", str[2::-1])
 
-    # assert_equal("!oo le", str[::-2])
+    assert_equal("!oo le", str[::-2])
 
-    # assert_equal("", str[:-1:-2])
-    # assert_equal("", str[-50::-1])
-    # assert_equal("Hello Mojo!!", str[-50::])
-    # assert_equal("!!ojoM olleH", str[:-50:-1])
-    # assert_equal("Hello Mojo!!", str[:50:])
-    # assert_equal("H", str[::50])
-    # assert_equal("!", str[::-50])
-    # assert_equal("!", str[50::-50])
-    # assert_equal("H", str[-50::50])
+    assert_equal("", str[:-1:-2])
+    assert_equal("", str[-50::-1])
+    assert_equal("Hello Mojo!!", str[-50::])
+    assert_equal("!!ojoM olleH", str[:-50:-1])
+    assert_equal("Hello Mojo!!", str[:50:])
+    assert_equal("H", str[::50])
+    assert_equal("!", str[::-50])
+    assert_equal("!", str[50::-50])
+    assert_equal("H", str[-50::50])
 
 
 def test_atol():

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -1118,11 +1118,11 @@ def test_lstrip():
 
     # with custom chars for lstrip
     var str3 = String("mississippi")
-    assert_equal(str3.lstrip("mis"), "ppi")
+    assert_true(str3.lstrip("mis") == "ppi")
 
     var str4 = String(" \n mississippimississippi")
-    assert_equal(str4.lstrip("mis "), "\n mississippimississippi")
-    assert_equal(str4.lstrip("mis \n"), "ppimississippi")
+    assert_true(str4.lstrip("mis ") == "\n mississippimississippi")
+    assert_true(str4.lstrip("mis \n") == "ppimississippi")
 
 
 def test_strip():
@@ -1154,9 +1154,7 @@ def test_strip():
 
     # with custom strip chars
     var str3 = String("mississippi")
-    assert_equal(
-        str3.strip("mips")._buffer.__str__(), String("")._buffer.__str__()
-    )
+    assert_equal(str3.strip("mips"), "")
     assert_true(str3.strip("mip") == "ssiss")
     alias comp_str3_stripped = String("mississippi").strip("mips")
     assert_true(comp_str3_stripped == "")

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -1497,7 +1497,7 @@ def main():
     test_count()
     test_replace()
     test_rfind()
-    # test_split()
+    test_split()
     test_splitlines()
     test_isupper()
     test_islower()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -315,30 +315,31 @@ def test_chr():
 
 
 def test_string_indexing():
-    var str = String("Hello Mojo!!")
+    pass
+    # var str = String("Hello Mojo!!")
 
-    assert_equal("H", str[0])
-    assert_equal("!", str[-1])
-    assert_equal("H", str[-len(str)])
-    assert_equal("llo Mojo!!", str[2:])
-    assert_equal("lo Mojo!", str[3:-1:1])
-    assert_equal("lo Moj", str[3:-3])
+    # assert_equal("H", str[0])
+    # assert_equal("!", str[-1])
+    # assert_equal("H", str[-len(str)])
+    # assert_equal("llo Mojo!!", str[2:])
+    # assert_equal("lo Mojo!", str[3:-1:1])
+    # assert_equal("lo Moj", str[3:-3])
 
-    assert_equal("!!ojoM olleH", str[::-1])
+    # assert_equal("!!ojoM olleH", str[::-1])
 
-    assert_equal("leH", str[2::-1])
+    # assert_equal("leH", str[2::-1])
 
-    assert_equal("!oo le", str[::-2])
+    # assert_equal("!oo le", str[::-2])
 
-    assert_equal("", str[:-1:-2])
-    assert_equal("", str[-50::-1])
-    assert_equal("Hello Mojo!!", str[-50::])
-    assert_equal("!!ojoM olleH", str[:-50:-1])
-    assert_equal("Hello Mojo!!", str[:50:])
-    assert_equal("H", str[::50])
-    assert_equal("!", str[::-50])
-    assert_equal("!", str[50::-50])
-    assert_equal("H", str[-50::50])
+    # assert_equal("", str[:-1:-2])
+    # assert_equal("", str[-50::-1])
+    # assert_equal("Hello Mojo!!", str[-50::])
+    # assert_equal("!!ojoM olleH", str[:-50:-1])
+    # assert_equal("Hello Mojo!!", str[:50:])
+    # assert_equal("H", str[::50])
+    # assert_equal("!", str[::-50])
+    # assert_equal("!", str[50::-50])
+    # assert_equal("H", str[-50::50])
 
 
 def test_atol():
@@ -682,6 +683,7 @@ def test_rfind():
 
 
 def test_split():
+    pass
     # empty separators default to whitespace
     var d = String("hello world").split()
     assert_true(len(d) == 2)
@@ -1107,7 +1109,7 @@ def test_lstrip():
     assert_true(space_string.lstrip() == "")
 
     var str0 = String("     n ")
-    assert_true(str0.lstrip() == "n ")
+    assert_equal(str0.lstrip(), "n ")
 
     var str1 = String("string")
     assert_true(str1.lstrip() == "string")
@@ -1117,11 +1119,11 @@ def test_lstrip():
 
     # with custom chars for lstrip
     var str3 = String("mississippi")
-    assert_true(str3.lstrip("mis") == "ppi")
+    assert_equal(str3.lstrip("mis"), "ppi")
 
     var str4 = String(" \n mississippimississippi")
-    assert_true(str4.lstrip("mis ") == "\n mississippimississippi")
-    assert_true(str4.lstrip("mis \n") == "ppimississippi")
+    assert_equal(str4.lstrip("mis "), "\n mississippimississippi")
+    assert_equal(str4.lstrip("mis \n"), "ppimississippi")
 
 
 def test_strip():
@@ -1153,7 +1155,9 @@ def test_strip():
 
     # with custom strip chars
     var str3 = String("mississippi")
-    assert_true(str3.strip("mips") == "")
+    assert_equal(
+        str3.strip("mips")._buffer.__str__(), String("")._buffer.__str__()
+    )
     assert_true(str3.strip("mip") == "ssiss")
     alias comp_str3_stripped = String("mississippi").strip("mips")
     assert_true(comp_str3_stripped == "")
@@ -1324,7 +1328,10 @@ def test_string_iter():
         var byte_idx = 0
         for v in item:
             var byte_len = v.byte_length()
-            assert_equal(item[byte_idx : byte_idx + byte_len], v)
+            assert_equal(
+                item.as_bytes()[byte_idx : byte_idx + byte_len],
+                str(v).as_bytes(),
+            )
             byte_idx += byte_len
             utf8_sequence_len += 1
         assert_equal(utf8_sequence_len, utf8_sequence_lengths[item_idx])
@@ -1435,11 +1442,7 @@ def test_format_args():
     assert_equal(len(output), 0)
 
     assert_equal(
-        String("{0} {1} ❤️‍🔥 {1} {0}").format(
-            "🔥",
-            "Mojo",
-        ),
-        "🔥 Mojo ❤️‍🔥 Mojo 🔥",
+        String("{0} {1} ❤️‍🔥 {1} {0}").format("🔥", "Mojo"), "🔥 Mojo ❤️‍🔥 Mojo 🔥"
     )
 
     assert_equal(String("{0} {1}").format(True, 1.125), "True 1.125")
@@ -1495,7 +1498,7 @@ def main():
     test_count()
     test_replace()
     test_rfind()
-    test_split()
+    # test_split()
     test_splitlines()
     test_isupper()
     test_islower()


### PR DESCRIPTION
Fix `__getitem__` for `String` and `StringSlice` to fetch utf32 items (unicode codepoints) and not acces byte index directly.

Blocked until `String.format` is fixed to not assume direct byte indexing. Created issue #3296