### PR TITLE
(fix) Fix broken link to hello-world program in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or the standalone Mojo SDK:
 - [Get the Mojo SDK](https://docs.modular.com/mojo/manual/get-started/)
 
 Then follow the docs to [write your first Mojo
-program](https://docs.modular.com/mojo/manual/get-started/hello-world).
+program](https://docs.modular.com/mojo/manual/get-started/#3-run-a-mojo-file).
 
 ### Latest Nightly
 


### PR DESCRIPTION
I recently became interested in mojo and noticed that the link to the docs for the hello world program in the `README.md` is broken.

I fixed it with what I believe to be the intended link. Let me know if it's another one...

Cheers