### PR TITLE
Update license section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ For more general questions or to chat with other Mojo developers, check out our
 
 ## License
 
-This repository and its contributions are licensed under the Apache License v2.0 with LLVM Exceptions (see the LLVM [License](https://llvm.org/LICENSE.txt)). MAX and Mojo usage and distribution are licensed under the [MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license).
+This repository and its contributions are licensed under the Apache License v2.0 
+with LLVM Exceptions (see the LLVM [License](https://llvm.org/LICENSE.txt)). 
+MAX and Mojo usage and distribution are licensed under the 
+[MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license).
 
 ## Thanks to our contributors
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For more general questions or to chat with other Mojo developers, check out our
 
 ## License
 
-This repository, and its contributions, are licensed under the Apache License v2.0 with LLVM Exceptions (see the LLVM [License](https://llvm.org/LICENSE.txt)). MAX and Mojo usage and distribution are licensed under the [MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license).
+This repository and its contributions are licensed under the Apache License v2.0 with LLVM Exceptions (see the LLVM [License](https://llvm.org/LICENSE.txt)). MAX and Mojo usage and distribution are licensed under the [MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license).
 
 ## Thanks to our contributors
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ For more general questions or to chat with other Mojo developers, check out our
 
 ## License
 
-This repository is licensed under the Apache License v2.0 with LLVM Exceptions
-(see the LLVM [License](https://llvm.org/LICENSE.txt)).
+This repository, and its contributions, are licensed under the Apache License v2.0 with LLVM Exceptions (see the LLVM [License](https://llvm.org/LICENSE.txt)). MAX and Mojo usage and distribution are licensed under the [MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license).
 
 ## Thanks to our contributors
 


### PR DESCRIPTION
Update license section of README to reflect current licensing of MAX and Mojo SDK (the [MAX & Mojo Community License](https://www.modular.com/legal/max-mojo-license)).