### PR TITLE
[docs] Delete rogue paren in docs

### DIFF
--- a/docs/manual/functions.ipynb
+++ b/docs/manual/functions.ipynb
@@ -166,7 +166,7 @@
     "  return an `object` by default.)\n",
     "\n",
     "- Arguments are mutable. Arguments default to using the `borrowed` \n",
-    "  [argument convention](/mojo/manual/values/ownership#argument-conventions))\n",
+    "  [argument convention](/mojo/manual/values/ownership#argument-conventions)\n",
     "  like an `fn` function, with a special addition: if the function mutates the\n",
     "  argument, it makes a mutable copy. \n",
     "\n",


### PR DESCRIPTION
Just deleting a loose parenthesis in the functions manual.