### PR TITLE
[docs] Remove rebind section in roadmap and update condicional conformance

### DIFF
--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -1778,6 +1778,74 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## The `rebind` builtin\n",
+    "One of the consequences of Mojo not performing function instantiation in the\n",
+    "parser like C++ is that Mojo cannot always figure out whether some parametric\n",
+    "types are equal and complain about an invalid conversion. This typically occurs\n",
+    "in static dispatch patterns, like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fn take_simd8(x: SIMD[DType.float32, 8]):\n",
+    "    pass\n",
+    "\n",
+    "fn generic_simd[nelts: Int](x: SIMD[DType.float32, nelts]):\n",
+    "    @parameter\n",
+    "    if nelts == 8:\n",
+    "        take_simd8(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parser will complain:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error: invalid call to 'take_simd8': argument #0 cannot be converted from\n",
+    "'SIMD[f32, nelts]' to 'SIMD[f32, 8]'\n",
+    "        take_simd8(x)\n",
+    "        ~~~~~~~~~~^~~"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is because the parser fully type-checks the function without instantiation,\n",
+    "and the type of `x` is still `SIMD[f32, nelts]`, and not `SIMD[f32, 8]`, despite\n",
+    "the static conditional. The remedy is to manually \"rebind\" the type of `x`,\n",
+    "using the `rebind` builtin, which inserts a compile-time assert that the input\n",
+    "and result types resolve to the same type after function instantiation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fn generic_simd[nelts: Int](x: SIMD[DType.float32, nelts]):\n",
+    "    @parameter\n",
+    "    if nelts == 8:\n",
+    "        take_simd8(rebind[SIMD[DType.float32, 8]](x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Legacy syntax (omitted parameters)\n",
     "\n",
     "You can also specify an unbound or partially-bound type by omitting parameters: \n",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -210,7 +210,7 @@ We plan to expand traits support in future releases. Planned features include:
 - Support for a feature like Swift's extensions, allowing you to add a trait to
   a preexisting type.
 
-- Add support for conditional conformance.
+- Improve support for conditional conformance.
 
 ## Classes
 


### PR DESCRIPTION
- Remove the `rebind` builtin from the roadmap, already implemented
- Update the conditional conformance support in roadmap, as it's partially implemented