### PR TITLE
Add `url` ID to docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yaml
@@ -12,6 +12,7 @@ body:
         Please add a title above and fill in the following fields so we can understand the problem.
 
   - type: input
+    id: url
     attributes:
       label: Where is the problem?
       description: Provide a link to the problematic page (with a heading anchor).


### PR DESCRIPTION
This allows us to pre-fill the "where is the problem" field with a `url` parameter in the URL.