### PR TITLE
[Docs] typo: "callee" -> "caller"

### DIFF
--- a/docs/manual/values/value-semantics.ipynb
+++ b/docs/manual/values/value-semantics.ipynb
@@ -249,7 +249,7 @@
     "\n",
     "Thus, the default behavior for `def` and `fn` arguments is fully value\n",
     "semantic: arguments are either copies or immutable references, and any living\n",
-    "variable from the callee is not affected by the function.\n",
+    "variable from the caller is not affected by the function.\n",
     "\n",
     "But we must also allow reference semantics (mutable references) because it's\n",
     "how we build performant and memory-efficient programs (making copies of\n",


### PR DESCRIPTION
I believe "callee" in the following should be "caller":

"any living variable from the callee is not affected by the function"