### PR TITLE
[stdlib] Add `String`, `StringSlice`, `Span`, and `List` method 'unsafe_slice()'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.magic/
+magic.lock
 
 # MacOS
 .DS_Store

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -734,8 +734,8 @@ struct List[T: CollectionElement, hint_trivial_type: Bool = False](
         if stop_normalized < 0:
             stop_normalized += len(self)
 
-        start_normalized = _clip(start_normalized, 0, len(self))
-        stop_normalized = _clip(stop_normalized, 0, len(self))
+        start_normalized = max(0, min(start_normalized, len(self)))
+        stop_normalized = max(0, min(stop_normalized, len(self)))
 
         for i in range(start_normalized, stop_normalized):
             if self[i] == value:
@@ -927,9 +927,34 @@ struct List[T: CollectionElement, hint_trivial_type: Bool = False](
         """
         return self.data
 
+    fn unsafe_slice(owned self, start_idx: UInt, end_idx: UInt) -> Self:
+        """Construct a `List` from self, start index, and end index.
+        Highly unsafe operation with no bounds checks and no negative indexing.
 
-fn _clip(value: Int, start: Int, end: Int) -> Int:
-    return max(start, min(value, end))
+        Args:
+            start_idx: The starting index.
+            end_idx: The end index.
+
+        Returns:
+            The resulting `List`.
+        """
+        debug_assert(
+            end_idx < len(self),
+            "`end_idx` is bigger than `len(self) -1`",
+        )
+        debug_assert(
+            start_idx < len(self),
+            "`start_idx` is bigger than `len(self) -1`",
+        )
+        debug_assert(
+            start_idx <= end_idx,
+            "`start_idx` is bigger than `end_idx`",
+        )
+        return Self(
+            unsafe_pointer=self.unsafe_ptr() + start_idx,
+            size=end_idx - start_idx,
+            capacity=self.capacity,
+        )
 
 
 fn _move_pointee_into_many_elements[

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -2207,6 +2207,54 @@ struct String(
         var result = String(buffer)
         return result^
 
+    @always_inline("nodebug")
+    fn unsafe_bytes_slice(
+        self, start_idx: UInt, end_idx: UInt
+    ) -> Span[__lifetime_of(self)]:
+        """Construct a `Span` from self, start index, and end index. Highly
+        unsafe operation with no bounds checks and no negative indexing.
+
+        Args:
+            start_idx: The starting index.
+            end_idx: The end index.
+
+        Returns:
+            The resulting `Span`.
+        """
+        return self.as_bytes_slice().unsafe_slice(start_idx, end_idx)
+
+    @always_inline("nodebug")
+    fn unsafe_string_slice(
+        self, start_idx: UInt, end_idx: UInt
+    ) -> StringSlice[__lifetime_of(self)]:
+        """Construct a `StringSlice` from self, start index, and end index (in
+        Unicode codepoints). Highly unsafe operation with no bounds checks and
+        no negative indexing.
+
+        Args:
+            start_idx: The starting index.
+            end_idx: The end index.
+
+        Returns:
+            The resulting `StringSlice`.
+        """
+        return self.as_string_slice().unsafe_slice(start_idx, end_idx)
+
+    @always_inline("nodebug")
+    fn unsafe_slice(self, start_idx: UInt, end_idx: UInt) -> Self:
+        """Construct a `String` from self, start index, and end index (in
+        Unicode codepoints). Highly unsafe operation with no bounds checks and
+        no negative indexing.
+
+        Args:
+            start_idx: The starting index.
+            end_idx: The end index.
+
+        Returns:
+            The resulting `String`.
+        """
+        return Self(self.unsafe_string_slice(start_idx, end_idx))
+
 
 # ===----------------------------------------------------------------------=== #
 # Utilities

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -330,3 +330,31 @@ struct Span[
         return Span[T, _lit_mut_cast[lifetime, False].result](
             unsafe_ptr=self._data, len=self._len
         )
+
+    @always_inline("nodebug")
+    fn unsafe_slice(self, start_idx: UInt, end_idx: UInt) -> Self:
+        """Construct a `Span` from self, start index, and end index. Highly
+        unsafe operation with no bounds checks and no negative indexing.
+
+        Args:
+            start_idx: The starting index.
+            end_idx: The end index.
+
+        Returns:
+            The resulting `Span`.
+        """
+        debug_assert(
+            end_idx < len(self),
+            "`end_idx` is bigger than `len(self) -1`",
+        )
+        debug_assert(
+            start_idx < len(self),
+            "`start_idx` is bigger than `len(self) -1`",
+        )
+        debug_assert(
+            start_idx <= end_idx,
+            "`start_idx` is bigger than `end_idx`",
+        )
+        return Self(
+            unsafe_ptr=self.unsafe_ptr() + start_idx, len=end_idx - start_idx
+        )


### PR DESCRIPTION
Add `String`, `StringSlice`, `Span`, and `List` method 'unsafe_slice()'

Proposed solution for [this comment/issue](https://github.com/modularml/mojo/pull/3528#discussion_r1771784689) and for other performance sensitive use cases where the user would have to use `unsafe_ptr()` and repeat this code anyway.

Will add tests if you guys agree with the approach @JoeLoser @laszlokindrat @ConnorGray 