### PR TITLE
[CI] Fix pre-commit filename use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         stages: [commit]
       - id: check-license
         name: check-license
-        entry: mojo stdlib/scripts/check-licenses.mojo
+        entry: mojo stdlib/scripts/check_licenses.mojo
         language: system
         files: '\.(mojo|🔥|py)$'
         stages: [commit]


### PR DESCRIPTION
a5a1e886139d2bc98c7f8c0e6bcada9ed6255818 changed the name of the `check-licenses.mojo` file, but this happened internally, and broke the external use of the name.  Fix this to account for the new name.

Note:
- We may want to change `check-docstrings.py` to comply with the new scheme, but we'll save that for later.
- This file isn't managed by copybara, so that's why this was subject to said breakage to begin with.