### PR TITLE
[stdlib] Use `@doc_private` on initializers from MLIR types

### DIFF
--- a/stdlib/src/builtin/bool.mojo
+++ b/stdlib/src/builtin/bool.mojo
@@ -128,6 +128,7 @@ struct Bool(
         """
         self.value = other.value
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.i1):
         """Construct a Bool value given a __mlir_type.i1 value.
@@ -137,6 +138,7 @@ struct Bool(
         """
         self.value = value
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!pop.scalar<bool>`):
         """Construct a Bool value given a `!pop.scalar<bool>` value.

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -170,6 +170,7 @@ struct VariadicList[type: AnyTrivialRegType](Sized):
         """
         self = value
 
+    @doc_private
     @always_inline
     fn __init__(inout self, value: Self._mlir_type):
         """Constructs a VariadicList from a variadic argument type.
@@ -310,6 +311,7 @@ struct VariadicListMem[
     # ===-------------------------------------------------------------------===#
 
     # Provide support for borrowed variadic arguments.
+    @doc_private
     @always_inline
     fn __init__(inout self, value: Self._mlir_type):
         """Constructs a VariadicList from a variadic argument type.
@@ -564,6 +566,7 @@ struct VariadicPack[
     # Life cycle methods
     # ===-------------------------------------------------------------------===#
 
+    @doc_private
     @always_inline
     fn __init__(inout self, value: Self._mlir_type, is_owned: Bool):
         """Constructs a VariadicPack from the internal representation.

--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -322,6 +322,7 @@ struct Int(
         """
         self = other
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.index):
         """Construct Int from the given index value.
@@ -331,6 +332,7 @@ struct Int(
         """
         self.value = value
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!pop.scalar<si16>`):
         """Construct Int from the given Int16 value.
@@ -344,6 +346,7 @@ struct Int(
             )
         )
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!pop.scalar<si32>`):
         """Construct Int from the given Int32 value.
@@ -357,6 +360,7 @@ struct Int(
             )
         )
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!pop.scalar<si64>`):
         """Construct Int from the given Int64 value.
@@ -370,6 +374,7 @@ struct Int(
             )
         )
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!pop.scalar<index>`):
         """Construct Int from the given Index value.

--- a/stdlib/src/builtin/int_literal.mojo
+++ b/stdlib/src/builtin/int_literal.mojo
@@ -57,6 +57,7 @@ struct IntLiteral(
         """Default constructor."""
         self.value = __mlir_attr.`#kgen.int_literal<0> : !kgen.int_literal`
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.`!kgen.int_literal`):
         """Construct IntLiteral from the given mlir !kgen.int_literal value.

--- a/stdlib/src/builtin/uint.mojo
+++ b/stdlib/src/builtin/uint.mojo
@@ -54,6 +54,7 @@ struct UInt(IntLike):
         """Default constructor that produces zero."""
         self.value = __mlir_op.`index.constant`[value = __mlir_attr.`0:index`]()
 
+    @doc_private
     @always_inline("nodebug")
     fn __init__(inout self, value: __mlir_type.index):
         """Construct UInt from the given index value.

--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -102,6 +102,7 @@ struct Optional[T: CollectionElement](
     # TODO(MSTDL-715):
     #   This initializer should not be necessary, we should need
     #   only the initilaizer from a `NoneType`.
+    @doc_private
     fn __init__(inout self, value: NoneType._mlir_type):
         """Construct an empty Optional.
 
@@ -435,6 +436,7 @@ struct OptionalReg[T: AnyTrivialRegType](Boolable):
     # TODO(MSTDL-715):
     #   This initializer should not be necessary, we should need
     #   only the initilaizer from a `NoneType`.
+    @doc_private
     fn __init__(inout self, value: NoneType._mlir_type):
         """Construct an empty Optional.
 

--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -96,6 +96,7 @@ struct UnsafePointer[
         """Create a null pointer."""
         self.address = __mlir_attr[`#interp.pointer<0> : `, Self._mlir_type]
 
+    @doc_private
     @always_inline
     fn __init__(inout self, value: Self._mlir_type):
         """Create a pointer with the input value.

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -140,6 +140,7 @@ struct PythonObject(
     # TODO(MSTDL-715):
     #   This initializer should not be necessary, we should need
     #   only the initilaizer from a `NoneType`.
+    @doc_private
     fn __init__(inout self, none: NoneType._mlir_type):
         """Initialize a none value object from a `None` literal.
 

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -187,6 +187,7 @@ struct StaticIntTuple[size: Int](
         """Constructs a static int tuple of the given size."""
         self = 0
 
+    @doc_private
     @always_inline
     fn __init__(inout self, value: __mlir_type.index):
         """Constructs a sized 1 static int tuple of given the element value.


### PR DESCRIPTION
### [Feature Request] Use @doc_private on initializers from MLIR types to hide them from the API docs #3563

#### Summary:
This PR adds the `@doc_private` decorator to all MLIR type constructors to exclude them from the generated API documentation. This was done to prevent exposing internal implementation details that are not relevant to the API users.

#### Changes:
- Applied `@doc_private` to all constructors of MLIR types.
  
#### Related Issue:
- Closes #3563
