### PR TITLE
Update variables.ipynb remove extra "from"

### DIFF
--- a/docs/manual/variables.ipynb
+++ b/docs/manual/variables.ipynb
@@ -171,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although Mojo can infer a variable type from from the first value assigned to a \n",
+    "Although Mojo can infer a variable type from the first value assigned to a \n",
     "variable, it also supports static type annotations on variables. Type \n",
     "annotations provide a more explicit way of specifying the variable's type.\n",
     "\n",


### PR DESCRIPTION
From appeared twice under the Type annotations section.