### PR TITLE
[stdlib] Implement `Writer` for `List`

### DIFF
--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -40,7 +40,7 @@ def test_list():
         list.append(i)
 
     assert_equal(5, len(list))
-    assert_equal(5 * sizeof[Int](), list.bytecount())
+    assert_equal(5 * sizeof[Int](), list.byte_length())
     assert_equal(0, list[0])
     assert_equal(1, list[1])
     assert_equal(2, list[2])


### PR DESCRIPTION
Implement `Writer` for `List`. Related to [#3738 (comment)](https://github.com/modularml/mojo/issues/3738#issuecomment-2457894333)