### PR TITLE
[stdlib] [mojo-lang] Add `type` and `origin` builtin functions

### DIFF
--- a/stdlib/src/base64/_b64encode.mojo
+++ b/stdlib/src/base64/_b64encode.mojo
@@ -287,7 +287,7 @@ fn _repeat_until[width: Int](v: SIMD) -> SIMD[v.type, width]:
     return _repeat_until[width](v.join(v))
 
 
-fn _rshift_bits_in_u16[shift: Int](input: Bytes) -> __type_of(input):
+fn _rshift_bits_in_u16[shift: Int](input: Bytes) -> type(input):
     var u16 = bitcast[DType.uint16, input.size // 2](input)
     var res = bit.rotate_bits_right[shift](u16)
     return bitcast[DType.uint8, input.size](res)

--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -61,7 +61,7 @@ fn count_leading_zeros[
         leading zeros at position `i` of the input value.
     """
     constrained[type.is_integral(), "must be integral"]()
-    return llvm_intrinsic["llvm.ctlz", __type_of(val), has_side_effect=False](
+    return llvm_intrinsic["llvm.ctlz", type(val), has_side_effect=False](
         val, False
     )
 
@@ -105,7 +105,7 @@ fn count_trailing_zeros[
         trailing zeros at position `i` of the input value.
     """
     constrained[type.is_integral(), "must be integral"]()
-    return llvm_intrinsic["llvm.cttz", __type_of(val), has_side_effect=False](
+    return llvm_intrinsic["llvm.cttz", type(val), has_side_effect=False](
         val, False
     )
 
@@ -149,9 +149,9 @@ fn bit_reverse[
         of an integer value of the element at position `i` of the input value.
     """
     constrained[type.is_integral(), "must be integral"]()
-    return llvm_intrinsic[
-        "llvm.bitreverse", __type_of(val), has_side_effect=False
-    ](val)
+    return llvm_intrinsic["llvm.bitreverse", type(val), has_side_effect=False](
+        val
+    )
 
 
 # ===----------------------------------------------------------------------===#
@@ -207,9 +207,7 @@ fn byte_swap[
         element at position `i` of the input value with its bytes swapped.
     """
     constrained[type.is_integral(), "must be integral"]()
-    return llvm_intrinsic["llvm.bswap", __type_of(val), has_side_effect=False](
-        val
-    )
+    return llvm_intrinsic["llvm.bswap", type(val), has_side_effect=False](val)
 
 
 # ===----------------------------------------------------------------------===#
@@ -251,9 +249,7 @@ fn pop_count[
         bits set in the element at position `i` of the input value.
     """
     constrained[type.is_integral(), "must be integral"]()
-    return llvm_intrinsic["llvm.ctpop", __type_of(val), has_side_effect=False](
-        val
-    )
+    return llvm_intrinsic["llvm.ctpop", type(val), has_side_effect=False](val)
 
 
 # ===----------------------------------------------------------------------===#
@@ -573,7 +569,7 @@ fn rotate_bits_left[
     elif shift < 0:
         return rotate_bits_right[-shift](x)
     else:
-        return llvm_intrinsic["llvm.fshl", __type_of(x), has_side_effect=False](
+        return llvm_intrinsic["llvm.fshl", type(x), has_side_effect=False](
             x, x, SIMD[type, width](shift)
         )
 
@@ -651,6 +647,6 @@ fn rotate_bits_right[
     elif shift < 0:
         return rotate_bits_left[-shift](x)
     else:
-        return llvm_intrinsic["llvm.fshr", __type_of(x), has_side_effect=False](
+        return llvm_intrinsic["llvm.fshr", type(x), has_side_effect=False](
             x, x, SIMD[type, width](shift)
         )

--- a/stdlib/src/builtin/_pybind.mojo
+++ b/stdlib/src/builtin/_pybind.mojo
@@ -66,9 +66,9 @@ fn fail_initialization(owned err: Error) -> PythonObject:
 fn pointer_bitcast[
     To: AnyType
 ](ptr: Pointer) -> Pointer[To, ptr.origin, ptr.address_space, *_, **_] as out:
-    return __type_of(out)(
+    return type(out)(
         _mlir_value=__mlir_op.`lit.ref.from_pointer`[
-            _type = __type_of(out)._mlir_type
+            _type = type(out)._mlir_type
         ](
             UnsafePointer(__mlir_op.`lit.ref.to_pointer`(ptr._value))
             .bitcast[To]()

--- a/stdlib/src/builtin/_stubs.mojo
+++ b/stdlib/src/builtin/_stubs.mojo
@@ -75,20 +75,20 @@ struct _ParamForIterator[IteratorT: Copyable]:
 
 
 fn declval[T: AnyType]() -> T:
-    constrained[False, "should only be used inside __type_of"]()
+    constrained[False, "should only be used inside type"]()
     while True:
         pass
 
 
 fn parameter_for_generator[
     T: _IntIterable,
-](range: T) -> _ParamForIterator[__type_of(declval[T]().__iter__())]:
+](range: T) -> _ParamForIterator[type(declval[T]().__iter__())]:
     return _generator(range.__iter__())
 
 
 fn parameter_for_generator[
     T: _StridedIterable,
-](range: T) -> _ParamForIterator[__type_of(declval[T]().__iter__())]:
+](range: T) -> _ParamForIterator[type(declval[T]().__iter__())]:
     return _generator(range.__iter__())
 
 

--- a/stdlib/src/builtin/math.mojo
+++ b/stdlib/src/builtin/math.mojo
@@ -175,7 +175,7 @@ fn max(x: UInt, y: UInt, /) -> UInt:
 
 
 @always_inline("nodebug")
-fn max(x: SIMD, y: __type_of(x), /) -> __type_of(x):
+fn max(x: SIMD, y: type(x), /) -> type(x):
     """Performs elementwise maximum of x and y.
 
     An element of the result SIMD vector will be the maximum of the
@@ -229,7 +229,7 @@ fn min(x: UInt, y: UInt, /) -> UInt:
 
 
 @always_inline("nodebug")
-fn min(x: SIMD, y: __type_of(x), /) -> __type_of(x):
+fn min(x: SIMD, y: type(x), /) -> type(x):
     """Gets the elementwise minimum of x and y.
 
     An element of the result SIMD vector will be the minimum of the
@@ -325,7 +325,7 @@ fn pow[T: Powable](base: T, exp: T) -> T:
     return base.__pow__(exp)
 
 
-fn pow(base: SIMD, exp: Int) -> __type_of(base):
+fn pow(base: SIMD, exp: Int) -> type(base):
     """Computes elementwise value of a SIMD vector raised to the power of the
     given integer.
 

--- a/stdlib/src/builtin/reversed.mojo
+++ b/stdlib/src/builtin/reversed.mojo
@@ -79,7 +79,7 @@ fn reversed[T: ReversibleRange](value: T) -> _StridedRange:
 fn reversed[
     T: CollectionElement
 ](ref [_]value: List[T, *_]) -> _ListIter[
-    T, __type_of(value).hint_trivial_type, __origin_of(value), False
+    T, type(value).hint_trivial_type, __origin_of(value), False
 ]:
     """Get a reversed iterator of the input list.
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2879,9 +2879,7 @@ fn _tbl1(
 @always_inline
 fn _pow[
     BaseTy: DType, simd_width: Int, ExpTy: DType
-](base: SIMD[BaseTy, simd_width], exp: SIMD[ExpTy, simd_width]) -> __type_of(
-    base
-):
+](base: SIMD[BaseTy, simd_width], exp: SIMD[ExpTy, simd_width]) -> type(base):
     """Computes the power of the elements of a SIMD vector raised to the
     corresponding elements of another SIMD vector.
 
@@ -2908,7 +2906,7 @@ fn _pow[
         if all(exp == 3):
             return base * base * base
 
-        var result = __type_of(base)()
+        var result = type(base)()
 
         @parameter
         for i in range(simd_width):
@@ -2916,17 +2914,17 @@ fn _pow[
         return result
     else:
         constrained[False, "unsupported type combination"]()
-        return __type_of(base)()
+        return type(base)()
 
 
 @always_inline
-fn _powf_scalar(base: Scalar, exponent: Scalar) -> __type_of(base):
+fn _powf_scalar(base: Scalar, exponent: Scalar) -> type(base):
     constrained[
         exponent.type.is_floating_point(), "exponent must be floating point"
     ]()
 
-    var integral: __type_of(exponent)
-    var fractional: __type_of(exponent)
+    var integral: type(exponent)
+    var fractional: type(exponent)
     integral, fractional = _modf_scalar(exponent)
 
     if integral == exponent:
@@ -2941,12 +2939,12 @@ fn _powf_scalar(base: Scalar, exponent: Scalar) -> __type_of(base):
 @always_inline
 fn _powf[
     simd_width: Int
-](base: SIMD[_, simd_width], exp: SIMD[_, simd_width]) -> __type_of(base):
+](base: SIMD[_, simd_width], exp: SIMD[_, simd_width]) -> type(base):
     constrained[
         exp.type.is_floating_point(), "exponent must be floating point"
     ]()
 
-    var result = __type_of(base)()
+    var result = type(base)()
 
     @parameter
     for i in range(simd_width):
@@ -2956,7 +2954,7 @@ fn _powf[
 
 
 @always_inline
-fn _powi[type: DType](base: Scalar[type], exp: Int32) -> __type_of(base):
+fn _powi[type: DType](base: Scalar[type], exp: Int32) -> type(base):
     if type.is_integral() and exp < 0:
         # Not defined for Integers, this should raise an
         # exception.
@@ -3174,7 +3172,7 @@ fn _format_scalar[
 # ===----------------------------------------------------------------------=== #
 
 
-fn _modf_scalar(x: Scalar) -> Tuple[__type_of(x), __type_of(x)]:
+fn _modf_scalar(x: Scalar) -> Tuple[type(x), type(x)]:
     constrained[x.type.is_floating_point(), "the type must be floating point"]()
     if x < 1:
         if x < 0:
@@ -3188,15 +3186,15 @@ fn _modf_scalar(x: Scalar) -> Tuple[__type_of(x), __type_of(x)]:
     return (f, x - f)
 
 
-fn _modf(x: SIMD) -> Tuple[__type_of(x), __type_of(x)]:
+fn _modf(x: SIMD) -> Tuple[type(x), type(x)]:
     constrained[x.type.is_numeric(), "the type must be numeric"]()
 
     @parameter
     if x.type.is_integral():
-        return (x, __type_of(x)(0))
+        return (x, type(x)(0))
 
-    var result_int = __type_of(x)()
-    var result_frac = __type_of(x)()
+    var result_int = type(x)()
+    var result_frac = type(x)()
 
     @parameter
     for i in range(x.size):
@@ -3214,7 +3212,7 @@ fn _sub_with_saturation[
     DType.uint8, width
 ]:
     # generates a single `vpsubusb` on x86 with AVX
-    return llvm_intrinsic["llvm.usub.sat", __type_of(a)](a, b)
+    return llvm_intrinsic["llvm.usub.sat", type(a)](a, b)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -3222,7 +3220,7 @@ fn _sub_with_saturation[
 # ===----------------------------------------------------------------------=== #
 
 
-fn _floor(x: SIMD) -> __type_of(x):
+fn _floor(x: SIMD) -> type(x):
     @parameter
     if x.type.is_integral():
         return x
@@ -3243,4 +3241,4 @@ fn _floor(x: SIMD) -> __type_of(x):
         bits & ~((1 << (shift_factor - e)) - 1),
         bits,
     )
-    return __type_of(x)(from_bits=bits)
+    return type(x)(from_bits=bits)

--- a/stdlib/src/builtin/sort.mojo
+++ b/stdlib/src/builtin/sort.mojo
@@ -214,7 +214,7 @@ fn _quicksort[
     # Work with an immutable span so we don't run into exclusivity problems with
     # the List[Span].
     var imm_span = span.get_immutable()
-    alias ImmSpan = __type_of(imm_span)
+    alias ImmSpan = type(imm_span)
 
     var stack = List[ImmSpan](capacity=_estimate_initial_height(size))
     stack.append(imm_span)

--- a/stdlib/src/builtin/type.mojo
+++ b/stdlib/src/builtin/type.mojo
@@ -1,0 +1,66 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Defines some type functions.
+
+These are Mojo built-ins, so you don't need to import them.
+"""
+
+
+@value
+struct _Type[T: AnyType]:
+    alias type = T
+
+
+@parameter
+fn type[T: AnyType, //](v: T) -> __type_of(_Type[__type_of(v)].type):
+    """Get the type of the argument.
+
+    Args:
+        v: The value
+
+    Returns:
+        The type of v.
+    """
+    return _Type[__type_of(v)].type
+
+
+# TODO: Should be a parametric alias.
+struct Origin[is_mutable: Bool]:
+    """This represents a origin reference of potentially parametric type.
+    TODO: This should be replaced with a parametric type alias.
+
+    Parameters:
+        is_mutable: Whether the origin reference is mutable.
+    """
+
+    alias type = __mlir_type[
+        `!lit.origin<`,
+        is_mutable.value,
+        `>`,
+    ]
+
+
+struct _Origin[is_mutable: Bool, //, origin: Origin[is_mutable].type]:
+    ...
+
+
+fn origin[T: AnyType, //](v: T) -> _Origin[__origin_of(v)].origin:
+    """Get the origin of the argument.
+
+    Args:
+        v: The value
+
+    Returns:
+        The origin of v.
+    """
+    return _Origin[__origin_of(v)].origin

--- a/stdlib/src/builtin/type.mojo
+++ b/stdlib/src/builtin/type.mojo
@@ -54,7 +54,7 @@ struct _Origin[is_mutable: Bool, //, origin: Origin[is_mutable].type]:
     ...
 
 
-fn origin[T: AnyType, //](v: T) -> _Origin[__origin_of(v)].origin:
+fn origin[T: AnyType, //](v: T) -> _Origin[__origin_of(v)].origin.type:
     """Get the origin of the argument.
 
     Args:

--- a/stdlib/src/builtin/type_aliases.mojo
+++ b/stdlib/src/builtin/type_aliases.mojo
@@ -40,20 +40,3 @@ alias StaticConstantOrigin = __mlir_attr[
 
 alias OriginSet = __mlir_type.`!lit.origin.set`
 """A set of origin parameters."""
-
-
-# Helper to build a value of !lit.origin type.
-# TODO: Should be a parametric alias.
-struct Origin[is_mutable: Bool]:
-    """This represents a origin reference of potentially parametric type.
-    TODO: This should be replaced with a parametric type alias.
-
-    Parameters:
-        is_mutable: Whether the origin reference is mutable.
-    """
-
-    alias type = __mlir_type[
-        `!lit.origin<`,
-        is_mutable.value,
-        `>`,
-    ]

--- a/stdlib/src/math/math.mojo
+++ b/stdlib/src/math/math.mojo
@@ -209,12 +209,12 @@ fn sqrt(x: Int) -> Int:
 
 
 @always_inline
-fn _sqrt_nvvm(x: SIMD) -> __type_of(x):
+fn _sqrt_nvvm(x: SIMD) -> type(x):
     constrained[
         x.type in (DType.float32, DType.float64), "must be f32 or f64 type"
     ]()
     alias instruction = "llvm.nvvm.sqrt.approx.ftz.f" if x.type is DType.float32 else "llvm.nvvm.sqrt.approx.d"
-    var res = __type_of(x)()
+    var res = type(x)()
 
     @parameter
     for i in range(x.size):
@@ -265,7 +265,7 @@ fn sqrt[
             return _sqrt_nvvm(x.cast[DType.float32]()).cast[x.type]()
         return _sqrt_nvvm(x)
 
-    return llvm_intrinsic["llvm.sqrt", __type_of(x), has_side_effect=False](x)
+    return llvm_intrinsic["llvm.sqrt", type(x), has_side_effect=False](x)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -274,13 +274,13 @@ fn sqrt[
 
 
 @always_inline
-fn _isqrt_nvvm(x: SIMD) -> __type_of(x):
+fn _isqrt_nvvm(x: SIMD) -> type(x):
     constrained[
         x.type in (DType.float32, DType.float64), "must be f32 or f64 type"
     ]()
 
     alias instruction = "llvm.nvvm.rsqrt.approx.ftz.f" if x.type is DType.float32 else "llvm.nvvm.rsqrt.approx.d"
-    var res = __type_of(x)()
+    var res = type(x)()
 
     @parameter
     for i in range(x.size):
@@ -291,7 +291,7 @@ fn _isqrt_nvvm(x: SIMD) -> __type_of(x):
 
 
 @always_inline
-fn isqrt(x: SIMD) -> __type_of(x):
+fn isqrt(x: SIMD) -> type(x):
     """Performs elementwise reciprocal square root on a SIMD vector.
 
     Args:
@@ -320,13 +320,13 @@ fn isqrt(x: SIMD) -> __type_of(x):
 
 
 @always_inline
-fn _recip_nvvm(x: SIMD) -> __type_of(x):
+fn _recip_nvvm(x: SIMD) -> type(x):
     constrained[
         x.type in (DType.float32, DType.float64), "must be f32 or f64 type"
     ]()
 
     alias instruction = "llvm.nvvm.rcp.approx.ftz.f" if x.type is DType.float32 else "llvm.nvvm.rcp.approx.ftz.d"
-    var res = __type_of(x)()
+    var res = type(x)()
 
     @parameter
     for i in range(x.size):
@@ -337,7 +337,7 @@ fn _recip_nvvm(x: SIMD) -> __type_of(x):
 
 
 @always_inline
-fn recip(x: SIMD) -> __type_of(x):
+fn recip(x: SIMD) -> type(x):
     """Performs elementwise reciprocal on a SIMD vector.
 
     Args:
@@ -420,7 +420,7 @@ fn exp2[
 
     var xc = x.clamp(-126, 126)
 
-    var m = xc.cast[__type_of(x.to_bits()).type]()
+    var m = xc.cast[type(x.to_bits()).type]()
 
     xc -= m.cast[type]()
 
@@ -434,7 +434,7 @@ fn exp2[
             1.33336498402e-3,
         ),
     ](xc)
-    return __type_of(r)(
+    return type(r)(
         from_bits=(r.to_bits() + (m << FPUtils[type].mantissa_width()))
     )
 
@@ -502,7 +502,7 @@ fn _ldexp_impl[
     alias integral_type = FPUtils[type].integral_type
     var m = exp.cast[integral_type]() + FPUtils[type].exponent_bias()
 
-    return x * __type_of(x)(from_bits=m << FPUtils[type].mantissa_width())
+    return x * type(x)(from_bits=m << FPUtils[type].mantissa_width())
 
 
 @always_inline
@@ -757,7 +757,7 @@ fn _log_base[
 
 
 @always_inline
-fn log(x: SIMD) -> __type_of(x):
+fn log(x: SIMD) -> type(x):
     """Performs elementwise natural log (base E) of a SIMD vector.
 
     Args:
@@ -791,7 +791,7 @@ fn log(x: SIMD) -> __type_of(x):
 
 
 @always_inline
-fn log2(x: SIMD) -> __type_of(x):
+fn log2(x: SIMD) -> type(x):
     """Performs elementwise log (base 2) of a SIMD vector.
 
     Args:
@@ -1034,10 +1034,7 @@ fn isclose[
         var res = (a == b) | (
             isfinite(a)
             & isfinite(b)
-            & (
-                abs(a - b)
-                <= max(__type_of(a)(atol), rtol * max(abs(a), abs(b)))
-            )
+            & (abs(a - b) <= max(type(a)(atol), rtol * max(abs(a), abs(b))))
         )
 
         return res | both_nan if equal_nan else res
@@ -1278,7 +1275,7 @@ fn align_up(value: UInt, alignment: UInt) -> UInt:
 # ===----------------------------------------------------------------------=== #
 
 
-fn acos(x: SIMD) -> __type_of(x):
+fn acos(x: SIMD) -> type(x):
     """Computes the `acos` of the inputs.
 
     Constraints:
@@ -1298,7 +1295,7 @@ fn acos(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn asin(x: SIMD) -> __type_of(x):
+fn asin(x: SIMD) -> type(x):
     """Computes the `asin` of the inputs.
 
     Constraints:
@@ -1318,7 +1315,7 @@ fn asin(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn atan(x: SIMD) -> __type_of(x):
+fn atan(x: SIMD) -> type(x):
     """Computes the `atan` of the inputs.
 
     Constraints:
@@ -1454,7 +1451,7 @@ fn sin[
 # ===----------------------------------------------------------------------=== #
 
 
-fn tan(x: SIMD) -> __type_of(x):
+fn tan(x: SIMD) -> type(x):
     """Computes the `tan` of the inputs.
 
     Constraints:
@@ -1474,7 +1471,7 @@ fn tan(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn acosh(x: SIMD) -> __type_of(x):
+fn acosh(x: SIMD) -> type(x):
     """Computes the `acosh` of the inputs.
 
     Constraints:
@@ -1494,7 +1491,7 @@ fn acosh(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn asinh(x: SIMD) -> __type_of(x):
+fn asinh(x: SIMD) -> type(x):
     """Computes the `asinh` of the inputs.
 
     Constraints:
@@ -1514,7 +1511,7 @@ fn asinh(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn atanh(x: SIMD) -> __type_of(x):
+fn atanh(x: SIMD) -> type(x):
     """Computes the `atanh` of the inputs.
 
     Constraints:
@@ -1534,7 +1531,7 @@ fn atanh(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn cosh(x: SIMD) -> __type_of(x):
+fn cosh(x: SIMD) -> type(x):
     """Computes the `cosh` of the inputs.
 
     Constraints:
@@ -1554,7 +1551,7 @@ fn cosh(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn sinh(x: SIMD) -> __type_of(x):
+fn sinh(x: SIMD) -> type(x):
     """Computes the `sinh` of the inputs.
 
     Constraints:
@@ -1575,7 +1572,7 @@ fn sinh(x: SIMD) -> __type_of(x):
 
 
 @always_inline
-fn expm1(x: SIMD) -> __type_of(x):
+fn expm1(x: SIMD) -> type(x):
     """Computes the `expm1` of the inputs.
 
     Constraints:
@@ -1595,7 +1592,7 @@ fn expm1(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn log10(x: SIMD) -> __type_of(x):
+fn log10(x: SIMD) -> type(x):
     """Computes the `log10` of the inputs.
 
     Constraints:
@@ -1631,7 +1628,7 @@ fn log10(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn log1p(x: SIMD) -> __type_of(x):
+fn log1p(x: SIMD) -> type(x):
     """Computes the `log1p` of the inputs.
 
     Constraints:
@@ -1651,7 +1648,7 @@ fn log1p(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn logb(x: SIMD) -> __type_of(x):
+fn logb(x: SIMD) -> type(x):
     """Computes the `logb` of the inputs.
 
     Constraints:
@@ -1671,7 +1668,7 @@ fn logb(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn cbrt(x: SIMD) -> __type_of(x):
+fn cbrt(x: SIMD) -> type(x):
     """Computes the `cbrt` of the inputs.
 
     Constraints:
@@ -1741,7 +1738,7 @@ fn hypot[
 # ===----------------------------------------------------------------------=== #
 
 
-fn erfc(x: SIMD) -> __type_of(x):
+fn erfc(x: SIMD) -> type(x):
     """Computes the `erfc` of the inputs.
 
     Constraints:
@@ -1761,7 +1758,7 @@ fn erfc(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn lgamma(x: SIMD) -> __type_of(x):
+fn lgamma(x: SIMD) -> type(x):
     """Computes the `lgamma` of the inputs.
 
     Constraints:
@@ -1781,7 +1778,7 @@ fn lgamma(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn gamma(x: SIMD) -> __type_of(x):
+fn gamma(x: SIMD) -> type(x):
     """Computes the Gamma of the input.
 
     For details, see https://en.wikipedia.org/wiki/Gamma_function.
@@ -1856,7 +1853,7 @@ fn remainder[
 # ===----------------------------------------------------------------------=== #
 
 
-fn j0(x: SIMD) -> __type_of(x):
+fn j0(x: SIMD) -> type(x):
     """Computes the Bessel function of the first kind of order 0 for each input
     value.
 
@@ -1877,7 +1874,7 @@ fn j0(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn j1(x: SIMD) -> __type_of(x):
+fn j1(x: SIMD) -> type(x):
     """Computes the Bessel function of the first kind of order 1 for each input
     value.
 
@@ -1898,7 +1895,7 @@ fn j1(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn y0(x: SIMD) -> __type_of(x):
+fn y0(x: SIMD) -> type(x):
     """Computes the Bessel function of the second kind of order 0 for each input
     value.
 
@@ -1919,7 +1916,7 @@ fn y0(x: SIMD) -> __type_of(x):
 # ===----------------------------------------------------------------------=== #
 
 
-fn y1(x: SIMD) -> __type_of(x):
+fn y1(x: SIMD) -> type(x):
     """Computes the Bessel function of the second kind of order 1 for each input
     value.
 
@@ -2148,7 +2145,7 @@ fn lcm(*values: Int) -> Int:
 # ===----------------------------------------------------------------------=== #
 
 
-fn modf(x: SIMD) -> Tuple[__type_of(x), __type_of(x)]:
+fn modf(x: SIMD) -> Tuple[type(x), type(x)]:
     """Computes the integral and fractional part of the value.
 
     Args:
@@ -2252,9 +2249,7 @@ fn factorial(n: Int) -> Int:
 # ===----------------------------------------------------------------------=== #
 
 
-fn clamp(
-    val: Int, lower_bound: __type_of(val), upper_bound: __type_of(val)
-) -> __type_of(val):
+fn clamp(val: Int, lower_bound: type(val), upper_bound: type(val)) -> type(val):
     """Clamps the integer value vector to be in a certain range.
 
     Args:
@@ -2269,8 +2264,8 @@ fn clamp(
 
 
 fn clamp(
-    val: UInt, lower_bound: __type_of(val), upper_bound: __type_of(val)
-) -> __type_of(val):
+    val: UInt, lower_bound: type(val), upper_bound: type(val)
+) -> type(val):
     """Clamps the integer value vector to be in a certain range.
 
     Args:
@@ -2285,8 +2280,8 @@ fn clamp(
 
 
 fn clamp(
-    val: SIMD, lower_bound: __type_of(val), upper_bound: __type_of(val)
-) -> __type_of(val):
+    val: SIMD, lower_bound: type(val), upper_bound: type(val)
+) -> type(val):
     """Clamps the values in a SIMD vector to be in a certain range.
 
     Clamp cuts values in the input SIMD vector off at the upper bound and

--- a/stdlib/src/memory/memory.mojo
+++ b/stdlib/src/memory/memory.mojo
@@ -51,7 +51,7 @@ fn _align_down(value: Int, alignment: Int) -> Int:
 @always_inline
 fn _memcmp_impl_unconstrained[
     type: DType
-](s1: UnsafePointer[Scalar[type], _], s2: __type_of(s1), count: Int) -> Int:
+](s1: UnsafePointer[Scalar[type], _], s2: type(s1), count: Int) -> Int:
     alias simd_width = simdwidthof[type]()
     if count < simd_width:
         for i in range(count):
@@ -95,7 +95,7 @@ fn _memcmp_impl_unconstrained[
 @always_inline
 fn _memcmp_impl[
     type: DType
-](s1: UnsafePointer[Scalar[type], _], s2: __type_of(s1), count: Int) -> Int:
+](s1: UnsafePointer[Scalar[type], _], s2: type(s1), count: Int) -> Int:
     constrained[type.is_integral(), "the input dtype must be integral"]()
     return _memcmp_impl_unconstrained(s1, s2, count)
 
@@ -144,7 +144,7 @@ fn memcmp[
 
 @always_inline
 fn _memcpy_impl(
-    dest_data: UnsafePointer[Byte, *_], src_data: __type_of(dest_data), n: Int
+    dest_data: UnsafePointer[Byte, *_], src_data: type(dest_data), n: Int
 ):
     """Copies a memory area.
 

--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -154,7 +154,7 @@ struct UnsafePointer[
         Returns:
             An UnsafePointer which contains the address of the argument.
         """
-        return __type_of(result)(
+        return type(result)(
             __mlir_op.`lit.ref.to_pointer`(__get_mvalue_as_litref(arg))
         )
 

--- a/stdlib/src/prelude/__init__.mojo
+++ b/stdlib/src/prelude/__init__.mojo
@@ -81,8 +81,8 @@ from builtin.type_aliases import (
     MutableAnyOrigin,
     StaticConstantOrigin,
     OriginSet,
-    Origin,
 )
+from builtin.type import Origin, type, origin
 from builtin.uint import UInt
 from builtin.value import (
     Movable,

--- a/stdlib/src/sys/ffi.mojo
+++ b/stdlib/src/sys/ffi.mojo
@@ -355,7 +355,7 @@ struct DLHandle(CollectionElement, CollectionElementNew, Boolable):
 
         debug_assert(self.check_symbol(name), "symbol not found: " + name)
         var v = args.get_loaded_kgen_pack()
-        return self.get_function[fn (__type_of(v)) -> return_type](name)(v)
+        return self.get_function[fn (type(v)) -> return_type](name)(v)
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -56,7 +56,7 @@ fn _reduce_and_fn(a: Bool, b: Bool) -> Bool:
 @always_inline
 fn _int_tuple_binary_apply[
     binary_fn: fn[type: DType] (Scalar[type], Scalar[type]) -> Scalar[type],
-](a: IndexList, b: __type_of(a)) -> __type_of(a):
+](a: IndexList, b: type(a)) -> type(a):
     """Applies a given element binary function to each pair of corresponding
     elements in two tuples.
 
@@ -73,7 +73,7 @@ fn _int_tuple_binary_apply[
         Tuple containing the result.
     """
 
-    var c = __type_of(a)()
+    var c = type(a)()
 
     @parameter
     for i in range(a.size):
@@ -87,7 +87,7 @@ fn _int_tuple_binary_apply[
 @always_inline
 fn _int_tuple_compare[
     comp_fn: fn[type: DType] (Scalar[type], Scalar[type]) -> Bool,
-](a: IndexList, b: __type_of(a)) -> StaticTuple[Bool, a.size]:
+](a: IndexList, b: type(a)) -> StaticTuple[Bool, a.size]:
     """Applies a given element compare function to each pair of corresponding
     elements in two tuples and produces a tuple of Bools containing result.
 
@@ -769,11 +769,11 @@ struct IndexList[
         """
         constrained[type.is_integral(), "the target type must be integral"]()
 
-        var res = __type_of(result)()
+        var res = type(result)()
 
         @parameter
         for i in range(size):
-            res.data[i] = rebind[__type_of(result.data).element_type](
+            res.data[i] = rebind[type(result.data).element_type](
                 rebind[Scalar[Self.element_type]](
                     self.data.__getitem__[i]()
                 ).cast[result.element_type]()
@@ -803,9 +803,9 @@ struct IndexList[
             element_bitwidth == Self.element_bitwidth
             and unsigned == Self.unsigned
         ):
-            return rebind[__type_of(result)](self)
+            return rebind[type(result)](self)
 
-        return rebind[__type_of(result)](
+        return rebind[type(result)](
             self.cast[_type_of_width[element_bitwidth, unsigned]()]()
         )
 
@@ -835,7 +835,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x))
+    return type(result)(int(x))
 
 
 @always_inline
@@ -856,7 +856,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x))
+    return type(result)(int(x))
 
 
 @always_inline
@@ -884,7 +884,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x), int(y))
+    return type(result)(int(x), int(y))
 
 
 @always_inline
@@ -906,7 +906,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x), int(y))
+    return type(result)(int(x), int(y))
 
 
 @always_inline
@@ -937,7 +937,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x), int(y), int(z))
+    return type(result)(int(x), int(y), int(z))
 
 
 @always_inline
@@ -971,7 +971,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x), int(y), int(z), int(w))
+    return type(result)(int(x), int(y), int(z), int(w))
 
 
 @always_inline
@@ -1008,7 +1008,7 @@ fn Index[
     Returns:
         The constructed IndexList.
     """
-    return __type_of(result)(int(x), int(y), int(z), int(w), int(v))
+    return type(result)(int(x), int(y), int(z), int(w), int(v))
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -114,7 +114,7 @@ fn _shift_unicode_to_utf8(ptr: UnsafePointer[UInt8], c: Int, num_bytes: Int):
         ptr[i] = ((c >> shift) & 0b0011_1111) | 0b1000_0000
 
 
-fn _utf8_byte_type(b: SIMD[DType.uint8, _], /) -> __type_of(b):
+fn _utf8_byte_type(b: SIMD[DType.uint8, _], /) -> type(b):
     """UTF-8 byte type.
 
     Returns:
@@ -1195,7 +1195,7 @@ struct _FormatCurlyEntry(CollectionElement, CollectionElementNew):
 
     @staticmethod
     fn format[T: Stringlike](fmt_src: T, args: Self._args_t) raises -> String:
-        alias len_pos_args = __type_of(args).__len__()
+        alias len_pos_args = type(args).__len__()
         entries, size_estimation = Self._create_entries(fmt_src, len_pos_args)
         var fmt_len = fmt_src.byte_length()
         var buf = String._buffer_type(capacity=fmt_len + size_estimation)

--- a/stdlib/src/utils/variant.mojo
+++ b/stdlib/src/utils/variant.mojo
@@ -107,7 +107,7 @@ struct Variant[*Ts: CollectionElement](
     # Fields
     alias _sentinel: Int = -1
     alias _mlir_type = __mlir_type[
-        `!kgen.variant<[rebind(:`, __type_of(Ts), ` `, Ts, `)]>`
+        `!kgen.variant<[rebind(:`, type(Ts), ` `, Ts, `)]>`
     ]
     var _impl: Self._mlir_type
 

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1019,8 +1019,8 @@ def test_deinterleave():
 
     var tup4 = SIMD[DType.index, 4](0, 1, 2, 3).deinterleave()
 
-    assert_equal(tup4[0], __type_of(tup4[0])(0, 2))
-    assert_equal(tup4[1], __type_of(tup4[0])(1, 3))
+    assert_equal(tup4[0], type(tup4[0])(0, 2))
+    assert_equal(tup4[1], type(tup4[0])(1, 3))
 
 
 def test_extract():
@@ -1586,8 +1586,8 @@ def test_modf():
 
 def test_split():
     var tup = SIMD[DType.index, 8](1, 2, 3, 4, 5, 6, 7, 8).split()
-    assert_equal(tup[0], __type_of(tup[0])(1, 2, 3, 4))
-    assert_equal(tup[1], __type_of(tup[1])(5, 6, 7, 8))
+    assert_equal(tup[0], type(tup[0])(1, 2, 3, 4))
+    assert_equal(tup[1], type(tup[1])(5, 6, 7, 8))
 
 
 def test_contains():


### PR DESCRIPTION
We need `type` and `origin` builtin functions. I tried doing it in this PR but the compiler doesn't seem to like my dynamic function even though it can be evaluated at comp time.

Whether on the compiler side or on the stdlib side, `__type_of()` and `__origin_of()` are ugly and not close to what python has.

BTW, this is also why I've been changing every use of `[type: DType]` as a parameter I've came across, it's a builtin function name and shouldn't be used as a parameter/argument/variable name IMO.

CC: @JoeLoser