### PR TITLE
[stdlib] [proposal] Add `del` builtin function

### DIFF
--- a/stdlib/src/base64/_b64encode.mojo
+++ b/stdlib/src/base64/_b64encode.mojo
@@ -205,7 +205,7 @@ fn store_incomplete_simd[
     ]()
 
     memcpy(dest=pointer, src=tmp_buffer_pointer, count=nb_of_elements_to_store)
-    _ = simd_vector  # We make it live long enough
+    del simd_vector^  # We make it live long enough
 
 
 # TODO: Use Span instead of List as input when Span is easier to use

--- a/stdlib/src/builtin/_pybind.mojo
+++ b/stdlib/src/builtin/_pybind.mojo
@@ -59,7 +59,7 @@ fn fail_initialization(owned err: Error) -> PythonObject:
         error_type,
         err.unsafe_cstr_ptr(),
     )
-    _ = err^
+    del err^
     return PythonObject(PyObjectPtr())
 
 

--- a/stdlib/src/builtin/anytype.mojo
+++ b/stdlib/src/builtin/anytype.mojo
@@ -65,3 +65,12 @@ trait AnyType:
         end of this function.
         """
         ...
+
+
+# TODO: this needs to take/consume the value, not copy implicitly
+fn del(owned args: VariadicPack[element_trait=AnyType]):
+    __type_of(args).__del__(args^)
+
+# TODO: this needs to take/consume the value, not copy implicitly
+fn del[*T: AnyType](owned *args: *T):
+    del(args)

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -484,7 +484,7 @@ struct VariadicPack[
 
     Parameters:
         elt_is_mutable: True if the elements of the list are mutable for an
-                        inout or owned argument pack.
+            inout or owned argument pack.
         origin: The reference origin of the underlying elements.
         element_trait: The trait that each element of the pack conforms to.
         element_types: The list of types held by the argument pack.
@@ -526,13 +526,13 @@ struct VariadicPack[
         # Immutable variadics never own the memory underlying them,
         # microoptimize out a check of _is_owned.
         @parameter
-        if Bool(elt_is_mutable):
+        if elt_is_mutable:
             # If the elements are unowned, just return.
             if not self._is_owned:
                 return
 
             @parameter
-            for i in reversed(range(Self.__len__())):
+            for i in reversed(range(len(Self))):
                 UnsafePointer.address_of(self[i]).destroy_pointee()
 
     # ===-------------------------------------------------------------------===#

--- a/stdlib/src/builtin/format_int.mojo
+++ b/stdlib/src/builtin/format_int.mojo
@@ -390,8 +390,7 @@ fn _try_write_int[
 
         process_digits[neg_digit_value]()
 
-    _ = remaining_int
-    _ = digit_chars_array
+    del (remaining_int^, digit_chars_array^)
 
     # Re-add +1 byte since the loop ended so we didn't write another char.
     offset += 1

--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -1773,7 +1773,7 @@ struct object(
             value: The value to append.
         """
         if self._value.is_obj():
-            _ = object(self._value.get_obj_attr("append"))(self, value)
+            del object(self._value.get_obj_attr("append"))(self, value)^
             return
         if not self._value.is_list():
             raise Error("TypeError: can only append to lists")
@@ -1858,7 +1858,7 @@ struct object(
             value: The value to set.
         """
         if self._value.is_obj():
-            _ = object(self._value.get_obj_attr("__setitem__"))(self, i, value)
+            del object(self._value.get_obj_attr("__setitem__"))(self, i, value)^
             return
         if self._value.is_str():
             raise Error(

--- a/stdlib/src/collections/counter.mojo
+++ b/stdlib/src/collections/counter.mojo
@@ -337,7 +337,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
             var key = key_ref[]
             if key not in other:
                 try:
-                    _ = self.pop(key)
+                    del self.pop(key)^
                 except:
                     pass  # this should not happen
             else:
@@ -386,7 +386,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
             var key = key_ref[]
             if self.get(key, 0) <= 0:
                 try:
-                    _ = self.pop(key)
+                    del self.pop(key)^
                 except:
                     pass  # this should not happen
 

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -875,7 +875,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
             break
 
         if key:
-            _ = self.pop(key.value())
+            del self.pop(key.value())^
             return DictEntry[K, V](key.value(), val.value())
 
         raise "KeyError: popitem(): dictionary is empty"

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -593,7 +593,7 @@ struct Set[T: KeyElement](Sized, Comparable, Hashable, Boolable):
         for _ in range(len(self)):
             # Can't fail from an empty set
             try:
-                _ = self.pop()
+                del self.pop()^
             except:
                 pass
 

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1416,7 +1416,7 @@ struct String(
             result.write(a)
 
         elems.each[add_elt]()
-        _ = is_first
+        del is_first^
         return result
 
     fn join[T: StringableCollectionElement](self, elems: List[T, *_]) -> String:

--- a/stdlib/src/os/os.mojo
+++ b/stdlib/src/os/os.mojo
@@ -154,7 +154,7 @@ struct _DirHandle:
             if name_str == "." or name_str == "..":
                 continue
             res.append(name_str)
-            _ = name^
+            del name^
 
         return res
 
@@ -180,7 +180,7 @@ struct _DirHandle:
             if name_str == "." or name_str == "..":
                 continue
             res.append(name_str)
-            _ = name^
+            del name^
 
         return res
 

--- a/stdlib/src/prelude/__init__.mojo
+++ b/stdlib/src/prelude/__init__.mojo
@@ -14,7 +14,7 @@
   that are automatically imported into every Mojo program.
 """
 
-from builtin.anytype import AnyType
+from builtin.anytype import AnyType, del
 from builtin.bool import Boolable, ImplicitlyBoolable, Bool, bool, any, all
 from builtin.breakpoint import breakpoint
 from builtin.builtin_list import (

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -1050,7 +1050,7 @@ struct CPython:
             self._Py_REFCNT(value),
         )
 
-        _ = v
+        del v^
         return PyKeysValuePair {
             key: key,
             value: value,
@@ -1817,9 +1817,7 @@ struct CPython:
         )
 
         self._inc_total_rc()
-        _ = type
-        _ = value
-        _ = traceback
+        del (type^, value^, traceback^)
         return r
 
     fn PyErr_SetNone(inout self, type: PyObjectPtr):

--- a/stdlib/src/python/python.mojo
+++ b/stdlib/src/python/python.mojo
@@ -149,8 +149,7 @@ struct Python:
                 )
             )
             Python.throw_python_exception_if_error_state(cpython)
-            _ = code^
-            _ = result^
+            del (code^, result^)
             return module
         else:
             # We use the result of evaluating the expression directly, and allow

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -1462,7 +1462,7 @@ struct PythonObject(
             cpython.PyUnicode_AsUTF8AndSize(python_str.py_object)
         )
         # keep python object alive so the copy can occur
-        _ = python_str
+        del python_str^
         return mojo_str
 
     fn write_to[W: Writer](self, inout writer: W):
@@ -1523,7 +1523,7 @@ struct PythonObject(
         var result = UnsafePointer.address_of(tmp).bitcast[
             UnsafePointer[Scalar[type]]
         ]()[]
-        _ = tmp
+        del tmp^
         return result
 
     fn _get_ptr_as_int(self) -> Int:

--- a/stdlib/src/sys/ffi.mojo
+++ b/stdlib/src/sys/ffi.mojo
@@ -225,7 +225,7 @@ struct DLHandle(CollectionElement, CollectionElementNew, Boolable):
         var result = UnsafePointer.address_of(opaque_function_ptr).bitcast[
             result_type
         ]()[]
-        _ = opaque_function_ptr
+        del opaque_function_ptr^
         return result
 
     @always_inline
@@ -405,7 +405,7 @@ fn _get_dylib_function[
     var func_ptr = _get_global_or_null[func_cache_name]()
     if func_ptr:
         var result = UnsafePointer.address_of(func_ptr).bitcast[result_type]()[]
-        _ = func_ptr
+        del func_ptr^
         return result
 
     var dylib = _get_dylib[name, init_fn, destroy_fn](payload)

--- a/stdlib/src/sys/intrinsics.mojo
+++ b/stdlib/src/sys/intrinsics.mojo
@@ -171,7 +171,7 @@ fn gather[
         mask,
         passthrough,
     )
-    _ = base
+    del base^
     return result
 
 
@@ -250,7 +250,7 @@ fn scatter[
         Int32(alignment),
         mask,
     )
-    _ = base
+    del base^
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/src/time/time.mojo
+++ b/stdlib/src/time/time.mojo
@@ -363,9 +363,7 @@ fn sleep(sec: Float64):
     var req = UnsafePointer[_CTimeSpec].address_of(tv_spec)
     var rem = UnsafePointer[_CTimeSpec]()
     _ = external_call["nanosleep", Int32](req, rem)
-    _ = tv_spec
-    _ = req
-    _ = rem
+    del (tv_spec^, req^, rem^)
 
 
 fn sleep(sec: Int):

--- a/stdlib/src/utils/numerics.mojo
+++ b/stdlib/src/utils/numerics.mojo
@@ -404,7 +404,7 @@ struct FlushDenormals:
             llvm_intrinsic["llvm.x86.sse.ldmxcsr", NoneType](
                 UnsafePointer[Int32].address_of(mxcsr)
             )
-            _ = mxcsr
+            del mxcsr^
             return
 
         alias ARM_FPCR_FZ = Int64(1) << 24

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -213,7 +213,7 @@ struct StaticTuple[element_type: AnyTrivialRegType, size: Int](Sized):
             UnsafePointer.address_of(arrayCopy).address, idx.__mlir_index__()
         )
         var result = UnsafePointer(ptr)[]
-        _ = arrayCopy
+        del arrayCopy^
         return result
 
     @always_inline("nodebug")

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -882,7 +882,7 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable].type,](
                 continue
             else:
                 return False
-        _ = next_line, unicode_line_sep, unicode_paragraph_sep
+        del (next_line^, unicode_line_sep^, unicode_paragraph_sep^)
         return True
 
     fn isnewline[single_character: Bool = False](self) -> Bool:
@@ -1348,7 +1348,7 @@ struct _FormatCurlyEntry(CollectionElement, CollectionElementNew):
                 conversion_flag not in Self.supported_conversion_flags
             ):
                 var f = String(_build_slice(field_ptr, new_idx, field_len))
-                _ = field^
+                del field^
                 raise Error('Conversion flag "' + f + '" not recognised.')
             self.conversion_flag = conversion_flag
             field = _build_slice(field_ptr, 0, exclamation_index)


### PR DESCRIPTION
Add `del` builtin function. I don't like doing `_ = value^`, if there is not going to be support on the language side then at least this function makes the intention of deletion clear. And until we have the `take`/`consume` keyword, the user will have to explicitly transfer `^` the value into the function (AFAIK the compiler will transfer anyway if no further uses are made).

The Mojo formatter seems to not like the definition of a function name equal to the `del` Python keyword and removes parenthesis. Not sure if you guys even want this function or will add support for it in the future. But can this issue be solved downstream? (I imagine you guys just forked black formatter).

If support for this is added on the compiler side later on, it should work the same anyway. Python also accepts:
```python
>>> a, b = "asd", 123
>>> del(a, b)
>>> print(a, b)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'a' is not defined
```

I'll be bold and @Mogball , is support for `del` on the compiler side planned?
