### PR TITLE
[Lit][CI] Exclude mojo files in examples subdirectories from lit

### DIFF
--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -29,6 +29,7 @@ config.excludes = [
     # No RUN: directive, just bare examples
     "hello_interop.mojo",
     "matmul.mojo",
+    "*/**.mojo",
 ]
 
 # Have the examples run in the build directory.


### PR DESCRIPTION
Some new examples that are being added are being tested as standalone `magic` projects, not with `lit`. Ignore these files from the lit config.

We may need to also add tests in CI for these separately, that could be a followup once we have some examples in place.