### PR TITLE
[CI][Lit] Ignore subdirectories of "examples" in lit config

### DIFF
--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+import os
 from pathlib import Path
 
 import lit.formats
@@ -29,8 +30,7 @@ config.excludes = [
     # No RUN: directive, just bare examples
     "hello_interop.mojo",
     "matmul.mojo",
-    "*/**.mojo",
-]
+] + [path.name for path in os.scandir("examples") if path.is_dir()]
 
 # Have the examples run in the build directory.
 # The `run-examples.sh` script creates the build directory.


### PR DESCRIPTION
Lit config doesn't support wildcards _or_ directories, but it does support entire folders, so here we're just searching for every folder under `examples` and adding it to the exclude.

I ran a quick test by copying `hello_interop.mojo` to `examples/project` (and renaming to `hello_interop2.mojo` to ignore the current excludes), then running `magic run examples`. The new file was correctly ignored.