### PR TITLE
[docs] Fix incorrect implicit type conversion output in variables.mdx documentation. 

### DIFF
--- a/docs/manual/variables.mdx
+++ b/docs/manual/variables.mdx
@@ -184,10 +184,11 @@ floating-point type, it converts the value instead of giving a compiler error:
 
 ```mojo
 var number: Float64 = Int(1)
+print(number)
 ```
 
 ```output
-1
+1.0
 ```
 
 As shown above, value assignment can be converted into a constructor call if the


### PR DESCRIPTION
…ntation

- The "Implicit type conversion" section shows the output of implicitly converting an Integer to Float64 as an Integer. It should have been a Float. Updated it to 1.0 instead of 1
- Also added a print statement in that code snippet.